### PR TITLE
Add xNAL to repository

### DIFF
--- a/src/xnal/doctypes/catalog.xml
+++ b/src/xnal/doctypes/catalog.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+   <nextCatalog catalog="dtd/catalog.xml"/>
+   <nextCatalog catalog="rng/catalog.xml"/>
+</catalog>

--- a/src/xnal/doctypes/dtd/catalog.xml
+++ b/src/xnal/doctypes/dtd/catalog.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+<!--DITA XNAL Domain-->
+   <public publicId="-//OASIS//ELEMENTS DITA 2.0 XNAL Domain//EN"
+           uri="xnalDomain.mod"/>
+   <public publicId="-//OASIS//ELEMENTS DITA 2.x XNAL Domain//EN"
+           uri="xnalDomain.mod"/>
+   <public publicId="-//OASIS//ENTITIES DITA 2.0 XNAL Domain//EN"
+           uri="xnalDomain.ent"/>
+   <public publicId="-//OASIS//ENTITIES DITA 2.x XNAL Domain//EN"
+           uri="xnalDomain.ent"/>
+</catalog>

--- a/src/xnal/doctypes/dtd/xnalDomain.ent
+++ b/src/xnal/doctypes/dtd/xnalDomain.ent
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!--                    HEADER                                     -->
+<!-- ============================================================= -->
+<!--  MODULE:    XNAL Domain                                       -->
+<!--  VERSION:   2.0                                               -->
+<!--  DATE:      [[[Release date]]]                                     -->
+<!--  PURPOSE:   Define elements and specialization atttributes    -->
+<!--             for the XNAL Domain                               -->
+<!--                                                               -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                    TYPICAL INVOCATION                         -->
+<!--                                                               -->
+<!--  Refer to this file by the following public identfier or an   -->
+<!--       appropriate system identifier                           -->
+<!-- PUBLIC "-//OASIS//ELEMENTS DITA 2.0 XNAL Domain//EN"              -->
+<!--       Delivered as file "xnalDomain.mod"                           -->
+<!-- ============================================================= -->
+<!--             (C) Copyright OASIS Open 2006, 2009.              -->
+<!--             All Rights Reserved.                              -->
+<!--  UPDATES:                                                     -->
+<!-- =============================================================   -->
+
+<!-- ============================================================= -->
+<!--                    ELEMENT EXTENSION ENTITY DECLARATIONS      -->
+<!-- ============================================================= -->
+
+<!ENTITY % xnal-d-author
+  "authorinformation"
+>
+
+<!-- ================ End DITA XNAL Domain ================== -->
+ 

--- a/src/xnal/doctypes/dtd/xnalDomain.mod
+++ b/src/xnal/doctypes/dtd/xnalDomain.mod
@@ -1,0 +1,475 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!--                    HEADER                                     -->
+<!-- ============================================================= -->
+<!--  MODULE:    XNAL Domain                                       -->
+<!--  VERSION:   2.0                                               -->
+<!--  DATE:      [[[Release date]]]                                     -->
+<!--  PURPOSE:   Define elements and specialization atttributes    -->
+<!--             for the XNAL Domain                               -->
+<!--                                                               -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                    TYPICAL INVOCATION                         -->
+<!--                                                               -->
+<!--  Refer to this file by the following public identfier or an   -->
+<!--       appropriate system identifier                           -->
+<!-- PUBLIC "-//OASIS//ELEMENTS DITA 2.0 XNAL Domain//EN"              -->
+<!--       Delivered as file "xnalDomain.mod"                           -->
+<!-- ============================================================= -->
+<!--             (C) Copyright OASIS Open 2006, 2009.              -->
+<!--             All Rights Reserved.                              -->
+<!--  UPDATES:                                                     -->
+<!-- =============================================================   -->
+
+<!-- ============================================================= -->
+<!--                   ELEMENT NAME ENTITIES                       -->
+<!-- ============================================================= -->
+
+<!ENTITY % authorinformation
+                       "authorinformation"                           >
+<!ENTITY % namedetails "namedetails"                                 >
+<!ENTITY % organizationnamedetails
+                       "organizationnamedetails"                     >
+<!ENTITY % organizationname
+                       "organizationname"                            >
+<!ENTITY % personname  "personname"                                  >
+<!ENTITY % honorific   "honorific"                                   >
+<!ENTITY % firstname   "firstname"                                   >
+<!ENTITY % middlename  "middlename"                                  >
+<!ENTITY % lastname    "lastname"                                    >
+<!ENTITY % generationidentifier
+                       "generationidentifier"                        >
+<!ENTITY % otherinfo   "otherinfo"                                   >
+<!ENTITY % addressdetails
+                       "addressdetails"                              >
+<!ENTITY % locality    "locality"                                    >
+<!ENTITY % localityname
+                       "localityname"                                >
+<!ENTITY % administrativearea
+                       "administrativearea"                          >
+<!ENTITY % thoroughfare
+                       "thoroughfare"                                >
+<!ENTITY % postalcode  "postalcode"                                  >
+<!ENTITY % country     "country"                                     >
+<!ENTITY % personinfo  "personinfo"                                  >
+<!ENTITY % organizationinfo
+                       "organizationinfo"                            >
+<!ENTITY % contactnumbers
+                       "contactnumbers"                              >
+<!ENTITY % contactnumber
+                       "contactnumber"                               >
+<!ENTITY % emailaddresses
+                       "emailaddresses"                              >
+<!ENTITY % emailaddress
+                       "emailaddress"                                >
+<!ENTITY % urls        "urls"                                        >
+<!ENTITY % url         "url"                                         >
+
+<!-- ============================================================= -->
+<!--                    ELEMENT DECLARATIONS                       -->
+<!-- ============================================================= -->
+
+<!--                    LONG NAME: Author Information              -->
+<!ENTITY % authorinformation.content
+                       "(%organizationinfo; |
+                         %personinfo;)*"
+>
+<!ENTITY % authorinformation.attributes
+              "%univ-atts;
+               href
+                          CDATA
+                                    #IMPLIED
+               format
+                          CDATA
+                                    #IMPLIED
+               type
+                          CDATA
+                                    #IMPLIED
+               scope
+                          (external |
+                           local |
+                           peer |
+                           -dita-use-conref-target)
+                                    #IMPLIED
+               keyref
+                          CDATA
+                                    #IMPLIED"
+>
+<!ELEMENT  authorinformation %authorinformation.content;>
+<!ATTLIST  authorinformation %authorinformation.attributes;>
+
+
+<!--                    LONG NAME: Name Details                    -->
+<!ENTITY % namedetails.content
+                       "(%organizationnamedetails; |
+                         %personname;)*"
+>
+<!ENTITY % namedetails.attributes
+              "%data-element-atts;"
+>
+<!ELEMENT  namedetails %namedetails.content;>
+<!ATTLIST  namedetails %namedetails.attributes;>
+
+
+<!--                    LONG NAME: Organization Details            -->
+<!ENTITY % organizationnamedetails.content
+                       "((%organizationname;)?,
+                         (%otherinfo;)*)"
+>
+<!ENTITY % organizationnamedetails.attributes
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
+>
+<!ELEMENT  organizationnamedetails %organizationnamedetails.content;>
+<!ATTLIST  organizationnamedetails %organizationnamedetails.attributes;>
+
+
+<!--                    LONG NAME: Organization Name               -->
+<!ENTITY % organizationname.content
+                       "(%ph.cnt;)*"
+>
+<!ENTITY % organizationname.attributes
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
+>
+<!ELEMENT  organizationname %organizationname.content;>
+<!ATTLIST  organizationname %organizationname.attributes;>
+
+
+<!--                    LONG NAME: Person Name                     -->
+<!ENTITY % personname.content
+                       "((%honorific;)?,
+                         (%firstname;)*,
+                         (%middlename;)*,
+                         (%lastname;)*,
+                         (%generationidentifier;)?,
+                         (%otherinfo;)*)"
+>
+<!ENTITY % personname.attributes
+              "%data-element-atts;"
+>
+<!ELEMENT  personname %personname.content;>
+<!ATTLIST  personname %personname.attributes;>
+
+
+<!--                    LONG NAME: Honorific                       -->
+<!ENTITY % honorific.content
+                       "(#PCDATA |
+                         %keyword; |
+                         %text;)*"
+>
+<!ENTITY % honorific.attributes
+              "%data-element-atts;"
+>
+<!ELEMENT  honorific %honorific.content;>
+<!ATTLIST  honorific %honorific.attributes;>
+
+
+<!--                    LONG NAME: First Name                      -->
+<!ENTITY % firstname.content
+                       "(#PCDATA |
+                         %keyword; |
+                         %text;)*"
+>
+<!ENTITY % firstname.attributes
+              "%data-element-atts;"
+>
+<!ELEMENT  firstname %firstname.content;>
+<!ATTLIST  firstname %firstname.attributes;>
+
+
+<!--                    LONG NAME: Middle Name                     -->
+<!ENTITY % middlename.content
+                       "(#PCDATA |
+                         %keyword; |
+                         %text;)*"
+>
+<!ENTITY % middlename.attributes
+              "%data-element-atts;"
+>
+<!ELEMENT  middlename %middlename.content;>
+<!ATTLIST  middlename %middlename.attributes;>
+
+
+<!--                    LONG NAME: Last Name                       -->
+<!ENTITY % lastname.content
+                       "(#PCDATA |
+                         %keyword; |
+                         %text;)*"
+>
+<!ENTITY % lastname.attributes
+              "%data-element-atts;"
+>
+<!ELEMENT  lastname %lastname.content;>
+<!ATTLIST  lastname %lastname.attributes;>
+
+
+<!--                    LONG NAME: Generation Identifier           -->
+<!ENTITY % generationidentifier.content
+                       "(#PCDATA |
+                         %keyword; |
+                         %text;)*"
+>
+<!ENTITY % generationidentifier.attributes
+              "%data-element-atts;"
+>
+<!ELEMENT  generationidentifier %generationidentifier.content;>
+<!ATTLIST  generationidentifier %generationidentifier.attributes;>
+
+
+<!--                    LONG NAME: Other Information               -->
+<!ENTITY % otherinfo.content
+                       "(%words.cnt;)*"
+>
+<!ENTITY % otherinfo.attributes
+              "%data-element-atts;"
+>
+<!ELEMENT  otherinfo %otherinfo.content;>
+<!ATTLIST  otherinfo %otherinfo.attributes;>
+
+
+<!--                    LONG NAME: Address Details                 -->
+<!ENTITY % addressdetails.content
+                       "(%words.cnt; |
+                         %administrativearea; |
+                         %country; |
+                         %locality; |
+                         %thoroughfare;)*"
+>
+<!ENTITY % addressdetails.attributes
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
+>
+<!ELEMENT  addressdetails %addressdetails.content;>
+<!ATTLIST  addressdetails %addressdetails.attributes;>
+
+
+<!--                    LONG NAME: Locality                        -->
+<!ENTITY % locality.content
+                       "(%words.cnt; |
+                         %localityname; |
+                         %postalcode;)*"
+>
+<!ENTITY % locality.attributes
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
+>
+<!ELEMENT  locality %locality.content;>
+<!ATTLIST  locality %locality.attributes;>
+
+
+<!--                    LONG NAME: Locality Name                   -->
+<!ENTITY % localityname.content
+                       "(%words.cnt;)*"
+>
+<!ENTITY % localityname.attributes
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
+>
+<!ELEMENT  localityname %localityname.content;>
+<!ATTLIST  localityname %localityname.attributes;>
+
+
+<!--                    LONG NAME: Administrative Area             -->
+<!ENTITY % administrativearea.content
+                       "(%words.cnt;)*"
+>
+<!ENTITY % administrativearea.attributes
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
+>
+<!ELEMENT  administrativearea %administrativearea.content;>
+<!ATTLIST  administrativearea %administrativearea.attributes;>
+
+
+<!--                    LONG NAME: Thoroughfare                    -->
+<!ENTITY % thoroughfare.content
+                       "(%words.cnt;)*"
+>
+<!ENTITY % thoroughfare.attributes
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
+>
+<!ELEMENT  thoroughfare %thoroughfare.content;>
+<!ATTLIST  thoroughfare %thoroughfare.attributes;>
+
+
+<!--                    LONG NAME: Postal Code                     -->
+<!ENTITY % postalcode.content
+                       "(#PCDATA |
+                         %keyword; |
+                         %text;)*"
+>
+<!ENTITY % postalcode.attributes
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
+>
+<!ELEMENT  postalcode %postalcode.content;>
+<!ATTLIST  postalcode %postalcode.attributes;>
+
+
+<!--                    LONG NAME: Country                         -->
+<!ENTITY % country.content
+                       "(#PCDATA |
+                         %keyword; |
+                         %text;)*"
+>
+<!ENTITY % country.attributes
+              "keyref
+                          CDATA
+                                    #IMPLIED
+               %univ-atts;"
+>
+<!ELEMENT  country %country.content;>
+<!ATTLIST  country %country.attributes;>
+
+
+<!--                    LONG NAME: Person Information              -->
+<!ENTITY % personinfo.content
+                       "((%namedetails;)?,
+                         (%addressdetails;)?,
+                         (%contactnumbers;)?,
+                         (%emailaddresses;)?)"
+>
+<!ENTITY % personinfo.attributes
+              "%data-element-atts;"
+>
+<!ELEMENT  personinfo %personinfo.content;>
+<!ATTLIST  personinfo %personinfo.attributes;>
+
+
+<!--                    LONG NAME: Organization Information        -->
+<!ENTITY % organizationinfo.content
+                       "((%namedetails;)?,
+                         (%addressdetails;)?,
+                         (%contactnumbers;)?,
+                         (%emailaddresses;)?,
+                         (%urls;)?)"
+>
+<!ENTITY % organizationinfo.attributes
+              "%data-element-atts;"
+>
+<!ELEMENT  organizationinfo %organizationinfo.content;>
+<!ATTLIST  organizationinfo %organizationinfo.attributes;>
+
+
+<!--                    LONG NAME: Contact Numbers                 -->
+<!ENTITY % contactnumbers.content
+                       "(%contactnumber;)*"
+>
+<!ENTITY % contactnumbers.attributes
+              "%data-element-atts;"
+>
+<!ELEMENT  contactnumbers %contactnumbers.content;>
+<!ATTLIST  contactnumbers %contactnumbers.attributes;>
+
+
+<!--                    LONG NAME: Contact Number                  -->
+<!ENTITY % contactnumber.content
+                       "(#PCDATA |
+                         %keyword; |
+                         %text;)*"
+>
+<!ENTITY % contactnumber.attributes
+              "%data-element-atts;"
+>
+<!ELEMENT  contactnumber %contactnumber.content;>
+<!ATTLIST  contactnumber %contactnumber.attributes;>
+
+
+<!--                    LONG NAME: Email Addresses                 -->
+<!ENTITY % emailaddresses.content
+                       "(%emailaddress;)*"
+>
+<!ENTITY % emailaddresses.attributes
+              "%data-element-atts;"
+>
+<!ELEMENT  emailaddresses %emailaddresses.content;>
+<!ATTLIST  emailaddresses %emailaddresses.attributes;>
+
+
+<!--                    LONG NAME: Email Address                   -->
+<!ENTITY % emailaddress.content
+                       "(%words.cnt;)*"
+>
+<!ENTITY % emailaddress.attributes
+              "%data-element-atts;"
+>
+<!ELEMENT  emailaddress %emailaddress.content;>
+<!ATTLIST  emailaddress %emailaddress.attributes;>
+
+
+<!--                    LONG NAME: URLs                            -->
+<!ENTITY % urls.content
+                       "(%url;)*"
+>
+<!ENTITY % urls.attributes
+              "%data-element-atts;"
+>
+<!ELEMENT  urls %urls.content;>
+<!ATTLIST  urls %urls.attributes;>
+
+
+<!--                    LONG NAME: URL                             -->
+<!ENTITY % url.content
+                       "(%words.cnt;)*"
+>
+<!ENTITY % url.attributes
+              "%data-element-atts;"
+>
+<!ELEMENT  url %url.content;>
+<!ATTLIST  url %url.attributes;>
+
+
+
+<!-- ============================================================= -->
+<!--             SPECIALIZATION ATTRIBUTE DECLARATIONS             -->
+<!-- ============================================================= -->
+  
+<!ATTLIST  addressdetails class CDATA "+ topic/ph xnal-d/addressdetails ">
+<!ATTLIST  administrativearea class CDATA "+ topic/ph xnal-d/administrativearea ">
+<!ATTLIST  authorinformation class CDATA "+ topic/author xnal-d/authorinformation ">
+<!ATTLIST  contactnumber class CDATA "+ topic/data xnal-d/contactnumber ">
+<!ATTLIST  contactnumbers class CDATA "+ topic/data xnal-d/contactnumbers ">
+<!ATTLIST  country      class CDATA "+ topic/ph xnal-d/country ">
+<!ATTLIST  emailaddress class CDATA "+ topic/data xnal-d/emailaddress ">
+<!ATTLIST  emailaddresses class CDATA "+ topic/data xnal-d/emailaddresses ">
+<!ATTLIST  firstname    class CDATA "+ topic/data xnal-d/firstname ">
+<!ATTLIST  generationidentifier class CDATA "+ topic/data xnal-d/generationidentifier ">
+<!ATTLIST  honorific    class CDATA "+ topic/data xnal-d/honorific ">
+<!ATTLIST  lastname     class CDATA "+ topic/data xnal-d/lastname ">
+<!ATTLIST  locality     class CDATA "+ topic/ph xnal-d/locality ">
+<!ATTLIST  localityname class CDATA "+ topic/ph xnal-d/localityname ">
+<!ATTLIST  middlename   class CDATA "+ topic/data xnal-d/middlename ">
+<!ATTLIST  namedetails  class CDATA "+ topic/data xnal-d/namedetails ">
+<!ATTLIST  organizationinfo class CDATA "+ topic/data xnal-d/organizationinfo ">
+<!ATTLIST  organizationname class CDATA "+ topic/ph xnal-d/organizationname ">
+<!ATTLIST  organizationnamedetails class CDATA "+ topic/ph xnal-d/organizationnamedetails ">
+<!ATTLIST  otherinfo    class CDATA "+ topic/data xnal-d/otherinfo ">
+<!ATTLIST  personinfo   class CDATA "+ topic/data xnal-d/personinfo ">
+<!ATTLIST  personname   class CDATA "+ topic/data xnal-d/personname ">
+<!ATTLIST  postalcode   class CDATA "+ topic/ph xnal-d/postalcode ">
+<!ATTLIST  thoroughfare class CDATA "+ topic/ph xnal-d/thoroughfare ">
+<!ATTLIST  url          class CDATA "+ topic/data xnal-d/url ">
+<!ATTLIST  urls         class CDATA "+ topic/data xnal-d/urls ">
+
+<!-- ================== End of DITA XNAL Domain ==================== -->
+ 

--- a/src/xnal/doctypes/rng/catalog.xml
+++ b/src/xnal/doctypes/rng/catalog.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+<!--DITA XNAL Domain-->
+   <group><!-- System ID (URL) catalog entries -->
+      <system systemId="urn:oasis:names:tc:dita:rng:xnalDomain.rng:2.0"
+              uri="xnalDomain.rng"/>
+      <system systemId="urn:oasis:names:tc:dita:rng:xnalDomain.rng:2.x"
+              uri="xnalDomain.rng"/>
+   </group>
+   <group><!-- Public ID (URN) catalog entries -->
+      <uri name="urn:oasis:names:tc:dita:rng:xnalDomain.rng:2.0"
+           uri="xnalDomain.rng"/>
+      <uri name="urn:oasis:names:tc:dita:rng:xnalDomain.rng:2.x"
+           uri="xnalDomain.rng"/>
+   </group>
+</catalog>

--- a/src/xnal/doctypes/rng/xnalDomain.rng
+++ b/src/xnal/doctypes/rng/xnalDomain.rng
@@ -1,0 +1,1006 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="urn:oasis:names:tc:dita:rng:vocabularyModuleDesc.rng"
+                         schematypens="http://relaxng.org/ns/structure/1.0"?>
+<grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:dita="http://dita.oasis-open.org/architecture/2005/" xmlns="http://relaxng.org/ns/structure/1.0">
+  <moduleDesc xmlns="http://dita.oasis-open.org/architecture/2005/">
+    <moduleTitle>DITA XNAL Domain</moduleTitle>
+    <headerComment xml:space="preserve">
+=============================================================
+                   HEADER                                    
+=============================================================
+ MODULE:    XNAL Domain                                      
+ VERSION:   2.0                                              
+ DATE:      [[[Release date]]]                                    
+ PURPOSE:   Define elements and specialization atttributes   
+            for the XNAL Domain                              
+                                                             
+=============================================================
+
+=============================================================
+                   PUBLIC DOCUMENT TYPE DEFINITION           
+                   TYPICAL INVOCATION                        
+                                                             
+ Refer to this file by the following public identfier or an 
+      appropriate system identifier 
+PUBLIC "-//OASIS//ELEMENTS DITA 2.0 XNAL Domain//EN"
+      Delivered as file "xnalDomain.mod"                          
+
+=============================================================
+            (C) Copyright OASIS Open 2006, 2009.             
+            All Rights Reserved.                             
+ UPDATES:                                                    
+=============================================================  
+</headerComment>
+    <moduleMetadata>
+      <moduleType>elementdomain</moduleType>
+      <moduleShortName>xnal-d</moduleShortName>
+      <modulePublicIds>
+        <dtdMod>-//OASIS//ELEMENTS DITA<var presep=" " name="ditaver"/> XNAL Domain//EN</dtdMod>
+        <dtdEnt>-//OASIS//ENTITIES DITA<var presep=" " name="ditaver"/> XNAL Domain//EN</dtdEnt>
+        <rngMod>urn:oasis:names:tc:dita:rng:xnalDomain.rng<var presep=":" name="ditaver"/></rngMod>
+      </modulePublicIds>
+    </moduleMetadata>
+  </moduleDesc>
+  <div>
+    <a:documentation>DOMAIN EXTENSION PATTERNS</a:documentation>
+
+    <define name="xnal-d-author">
+      <ref name="authorinformation.element"/>
+    </define>
+    <define name="author" combine="choice">
+      <ref name="xnal-d-author"/>
+    </define>
+
+
+    <define name="addressdetails">
+      <ref name="addressdetails.element"/>
+    </define>
+    <define name="administrativearea">
+      <ref name="administrativearea.element"/>
+    </define>
+    <define name="contactnumber">
+      <ref name="contactnumber.element"/>
+    </define>
+    <define name="contactnumbers">
+      <ref name="contactnumbers.element"/>
+    </define>
+    <define name="country">
+      <ref name="country.element"/>
+    </define>
+    <define name="emailaddress">
+      <ref name="emailaddress.element"/>
+    </define>
+    <define name="emailaddresses">
+      <ref name="emailaddresses.element"/>
+    </define>
+    <define name="firstname">
+      <ref name="firstname.element"/>
+    </define>
+    <define name="generationidentifier">
+      <ref name="generationidentifier.element"/>
+    </define>
+    <define name="honorific">
+      <ref name="honorific.element"/>
+    </define>
+    <define name="lastname">
+      <ref name="lastname.element"/>
+    </define>
+    <define name="locality">
+      <ref name="locality.element"/>
+    </define>
+    <define name="localityname">
+      <ref name="localityname.element"/>
+    </define>
+    <define name="middlename">
+      <ref name="middlename.element"/>
+    </define>
+    <define name="namedetails">
+      <ref name="namedetails.element"/>
+    </define>
+    <define name="organizationinfo">
+      <ref name="organizationinfo.element"/>
+    </define>
+    <define name="organizationname">
+      <ref name="organizationname.element"/>
+    </define>
+    <define name="organizationnamedetails">
+      <ref name="organizationnamedetails.element"/>
+    </define>
+    <define name="otherinfo">
+      <ref name="otherinfo.element"/>
+    </define>
+    <define name="personinfo">
+      <ref name="personinfo.element"/>
+    </define>
+    <define name="personname">
+      <ref name="personname.element"/>
+    </define>
+    <define name="postalcode">
+      <ref name="postalcode.element"/>
+    </define>
+    <define name="thoroughfare">
+      <ref name="thoroughfare.element"/>
+    </define>
+    <define name="url">
+      <ref name="url.element"/>
+    </define>
+    <define name="urls">
+      <ref name="urls.element"/>
+    </define>
+  </div>
+  <div>
+    <a:documentation> ELEMENT DECLARATIONS </a:documentation>
+    <div>
+      <a:documentation> LONG NAME: Author Information </a:documentation>
+      <define name="authorinformation.content">
+        <zeroOrMore>
+          <choice>
+            <ref name="organizationinfo"/>
+            <ref name="personinfo"/>
+          </choice>
+        </zeroOrMore>
+      </define>
+      <a:documentation>
+    20080128: Removed enumeration for @type for DITA 1.2 . Previous values:
+    creator, contributor, -dita-use-conref-target
+  </a:documentation>
+      <define name="authorinformation.attributes">
+        <ref name="univ-atts"/>
+        <optional>
+          <attribute name="href"/>
+        </optional>
+        <optional>
+          <attribute name="format"/>
+        </optional>
+        <optional>
+          <attribute name="type"/>
+        </optional>
+        <optional>
+          <attribute name="scope">
+            <choice>
+              <value>external</value>
+              <value>local</value>
+              <value>peer</value>
+              <value>-dita-use-conref-target</value>
+            </choice>
+          </attribute>
+        </optional>
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
+      </define>
+      <define name="authorinformation.element">
+        <element name="authorinformation" dita:longName="Author Information">
+          <a:documentation><![CDATA[The <authorinformation> element contains detailed information about the author or authoring organization.
+    Category: xNAL elements
+  ]]></a:documentation>
+          <ref name="authorinformation.attlist"/>
+          <ref name="authorinformation.content"/>
+        </element>
+      </define>
+      <define name="authorinformation.attlist" combine="interleave">
+        <ref name="authorinformation.attributes"/>
+      </define>
+    </div>
+    <div>
+      <a:documentation> LONG NAME: Name Details </a:documentation>
+      <define name="namedetails.content">
+        <zeroOrMore>
+          <choice>
+            <ref name="organizationnamedetails"/>
+            <ref name="personname"/>
+          </choice>
+        </zeroOrMore>
+      </define>
+      <define name="namedetails.attributes">
+        <ref name="data-element-atts"/>
+      </define>
+      <define name="namedetails.element">
+        <element name="namedetails" dita:longName="Name Details">
+          <a:documentation><![CDATA[The <namedetails> element contains information about the name of the author or the authoring organization.
+    Category: xNAL elements
+  ]]></a:documentation>
+          <ref name="namedetails.attlist"/>
+          <ref name="namedetails.content"/>
+        </element>
+      </define>
+      <define name="namedetails.attlist" combine="interleave">
+        <ref name="namedetails.attributes"/>
+      </define>
+    </div>
+    <div>
+      <a:documentation> LONG NAME: Organization Details </a:documentation>
+      <define name="organizationnamedetails.content">
+        <optional>
+          <ref name="organizationname"/>
+        </optional>
+        <zeroOrMore>
+          <ref name="otherinfo"/>
+        </zeroOrMore>
+      </define>
+      <define name="organizationnamedetails.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
+        <ref name="univ-atts"/>
+      </define>
+      <define name="organizationnamedetails.element">
+        <element name="organizationnamedetails" dita:longName="Organization Details">
+          <a:documentation><![CDATA[The <organizationnamedetails> element contains information about the name of an authoring organization.
+    Category: xNAL elements
+  ]]></a:documentation>
+          <ref name="organizationnamedetails.attlist"/>
+          <ref name="organizationnamedetails.content"/>
+        </element>
+      </define>
+      <define name="organizationnamedetails.attlist" combine="interleave">
+        <ref name="organizationnamedetails.attributes"/>
+      </define>
+    </div>
+    <div>
+      <a:documentation> LONG NAME: Organization Name </a:documentation>
+      <define name="organizationname.content">
+        <zeroOrMore>
+          <ref name="ph.cnt"/>
+        </zeroOrMore>
+      </define>
+      <define name="organizationname.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
+        <ref name="univ-atts"/>
+      </define>
+      <define name="organizationname.element">
+        <element name="organizationname" dita:longName="Organization Name">
+          <a:documentation><![CDATA[The <organizationname> element contains name information about the authoring organization.
+    Category: xNAL elements
+  ]]></a:documentation>
+          <ref name="organizationname.attlist"/>
+          <ref name="organizationname.content"/>
+        </element>
+      </define>
+      <define name="organizationname.attlist" combine="interleave">
+        <ref name="organizationname.attributes"/>
+      </define>
+    </div>
+    <div>
+      <a:documentation> LONG NAME: Person Name </a:documentation>
+      <define name="personname.content">
+        <optional>
+          <ref name="honorific"/>
+        </optional>
+        <zeroOrMore>
+          <ref name="firstname"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="middlename"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="lastname"/>
+        </zeroOrMore>
+        <optional>
+          <ref name="generationidentifier"/>
+        </optional>
+        <zeroOrMore>
+          <ref name="otherinfo"/>
+        </zeroOrMore>
+      </define>
+      <define name="personname.attributes">
+        <ref name="data-element-atts"/>
+      </define>
+      <define name="personname.element">
+        <element name="personname" dita:longName="Person Name">
+          <a:documentation><![CDATA[The <personname> element contains name information about the author.
+    Category: xNAL elements
+  ]]></a:documentation>
+          <ref name="personname.attlist"/>
+          <ref name="personname.content"/>
+        </element>
+      </define>
+      <define name="personname.attlist" combine="interleave">
+        <ref name="personname.attributes"/>
+      </define>
+    </div>
+    <div>
+      <a:documentation> LONG NAME: Honorific </a:documentation>
+      <define name="honorific.content">
+        <zeroOrMore>
+          <choice>
+            <text/>
+            <ref name="keyword"/>
+            <ref name="text" dita:since="1.3"/>
+          </choice>
+        </zeroOrMore>
+      </define>
+      <define name="honorific.attributes">
+        <ref name="data-element-atts"/>
+      </define>
+      <define name="honorific.element">
+        <element name="honorific" dita:longName="Honorific">
+          <a:documentation><![CDATA[The <honorific> element contains the person's title, such as: Dr., Mr., Ms., HRH.. or Grand Exalted Wizard.
+    Category: xNAL elements
+  ]]></a:documentation>
+          <ref name="honorific.attlist"/>
+          <ref name="honorific.content"/>
+        </element>
+      </define>
+      <define name="honorific.attlist" combine="interleave">
+        <ref name="honorific.attributes"/>
+      </define>
+    </div>
+    <div>
+      <a:documentation> LONG NAME: First Name </a:documentation>
+      <define name="firstname.content">
+        <zeroOrMore>
+          <choice>
+            <text/>
+            <ref name="keyword"/>
+            <ref name="text" dita:since="1.3"/>
+          </choice>
+        </zeroOrMore>
+      </define>
+      <define name="firstname.attributes">
+        <ref name="data-element-atts"/>
+      </define>
+      <define name="firstname.element">
+        <element name="firstname" dita:longName="First Name">
+          <a:documentation><![CDATA[The <firstname> element contains the person's first name.
+    Category: xNAL elements
+  ]]></a:documentation>
+          <ref name="firstname.attlist"/>
+          <ref name="firstname.content"/>
+        </element>
+      </define>
+      <define name="firstname.attlist" combine="interleave">
+        <ref name="firstname.attributes"/>
+      </define>
+    </div>
+    <div>
+      <a:documentation> LONG NAME: Middle Name </a:documentation>
+      <define name="middlename.content">
+        <zeroOrMore>
+          <choice>
+            <text/>
+            <ref name="keyword"/>
+            <ref name="text" dita:since="1.3"/>
+          </choice>
+        </zeroOrMore>
+      </define>
+      <define name="middlename.attributes">
+        <ref name="data-element-atts"/>
+      </define>
+      <define name="middlename.element">
+        <element name="middlename" dita:longName="Middle Name">
+          <a:documentation><![CDATA[The <middlename> element contains the person's middle name or initial.
+    Category: xNAL elements
+  ]]></a:documentation>
+          <ref name="middlename.attlist"/>
+          <ref name="middlename.content"/>
+        </element>
+      </define>
+      <define name="middlename.attlist" combine="interleave">
+        <ref name="middlename.attributes"/>
+      </define>
+    </div>
+    <div>
+      <a:documentation> LONG NAME: Last Name </a:documentation>
+      <define name="lastname.content">
+        <zeroOrMore>
+          <choice>
+            <text/>
+            <ref name="keyword"/>
+            <ref name="text" dita:since="1.3"/>
+          </choice>
+        </zeroOrMore>
+      </define>
+      <define name="lastname.attributes">
+        <ref name="data-element-atts"/>
+      </define>
+      <define name="lastname.element">
+        <element name="lastname" dita:longName="Last Name">
+          <a:documentation><![CDATA[The <lastname> element contains the person's last name.
+    Category: xNAL elements
+  ]]></a:documentation>
+          <ref name="lastname.attlist"/>
+          <ref name="lastname.content"/>
+        </element>
+      </define>
+      <define name="lastname.attlist" combine="interleave">
+        <ref name="lastname.attributes"/>
+      </define>
+    </div>
+    <div>
+      <a:documentation> LONG NAME: Generation Identifier </a:documentation>
+      <define name="generationidentifier.content">
+        <zeroOrMore>
+          <choice>
+            <text/>
+            <ref name="keyword"/>
+            <ref name="text" dita:since="1.3"/>
+          </choice>
+        </zeroOrMore>
+      </define>
+      <define name="generationidentifier.attributes">
+        <ref name="data-element-atts"/>
+      </define>
+      <define name="generationidentifier.element">
+        <element name="generationidentifier" dita:longName="Generation Identifier">
+          <a:documentation><![CDATA[The <generationidentifier> element contains information about the person's generation, such as: Jr, III, or VIII.
+    Category: xNAL elements
+  ]]></a:documentation>
+          <ref name="generationidentifier.attlist"/>
+          <ref name="generationidentifier.content"/>
+        </element>
+      </define>
+      <define name="generationidentifier.attlist" combine="interleave">
+        <ref name="generationidentifier.attributes"/>
+      </define>
+    </div>
+    <div>
+      <a:documentation> LONG NAME: Other Information </a:documentation>
+      <define name="otherinfo.content">
+        <zeroOrMore>
+          <ref name="words.cnt"/>
+        </zeroOrMore>
+      </define>
+      <define name="otherinfo.attributes">
+        <ref name="data-element-atts"/>
+      </define>
+      <define name="otherinfo.element">
+        <element name="otherinfo" dita:longName="Other Information">
+          <a:documentation><![CDATA[The <otherinfo> element contains other name information about the author or authoring organization.
+    Category: xNAL elements
+  ]]></a:documentation>
+          <ref name="otherinfo.attlist"/>
+          <ref name="otherinfo.content"/>
+        </element>
+      </define>
+      <define name="otherinfo.attlist" combine="interleave">
+        <ref name="otherinfo.attributes"/>
+      </define>
+    </div>
+    <div>
+      <a:documentation> LONG NAME: Address Details </a:documentation>
+      <define name="addressdetails.content">
+        <zeroOrMore>
+          <choice>
+            <ref name="words.cnt"/>
+            <ref name="administrativearea"/>
+            <ref name="country"/>
+            <ref name="locality"/>
+            <ref name="thoroughfare"/>
+          </choice>
+        </zeroOrMore>
+      </define>
+      <define name="addressdetails.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
+        <ref name="univ-atts"/>
+      </define>
+      <define name="addressdetails.element">
+        <element name="addressdetails" dita:longName="Address Details">
+          <a:documentation><![CDATA[The <addressdetails> element contains information about the address of the author or authoring group.
+    Category: xNAL elements
+  ]]></a:documentation>
+          <ref name="addressdetails.attlist"/>
+          <ref name="addressdetails.content"/>
+        </element>
+      </define>
+      <define name="addressdetails.attlist" combine="interleave">
+        <ref name="addressdetails.attributes"/>
+      </define>
+    </div>
+    <div>
+      <a:documentation> LONG NAME: Locality </a:documentation>
+      <define name="locality.content">
+        <zeroOrMore>
+          <choice>
+            <ref name="words.cnt"/>
+            <ref name="localityname"/>
+            <ref name="postalcode"/>
+          </choice>
+        </zeroOrMore>
+      </define>
+      <define name="locality.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
+        <ref name="univ-atts"/>
+      </define>
+      <define name="locality.element">
+        <element name="locality" dita:longName="Locality">
+          <a:documentation><![CDATA[The <locality> element contains information about the city and postal or ZIP code. It can contain the information directly, or by acting as a wrapper for <localityname> and <postalcode>.
+    Category: xNAL elements
+  ]]></a:documentation>
+          <ref name="locality.attlist"/>
+          <ref name="locality.content"/>
+        </element>
+      </define>
+      <define name="locality.attlist" combine="interleave">
+        <ref name="locality.attributes"/>
+      </define>
+    </div>
+    <div>
+      <a:documentation> LONG NAME: Locality Name </a:documentation>
+      <define name="localityname.content">
+        <zeroOrMore>
+          <ref name="words.cnt"/>
+        </zeroOrMore>
+      </define>
+      <define name="localityname.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
+        <ref name="univ-atts"/>
+      </define>
+      <define name="localityname.element">
+        <element name="localityname" dita:longName="Locality Name">
+          <a:documentation><![CDATA[The <localityname> element contains the name of the locality or city.
+    Category: xNAL elements
+  ]]></a:documentation>
+          <ref name="localityname.attlist"/>
+          <ref name="localityname.content"/>
+        </element>
+      </define>
+      <define name="localityname.attlist" combine="interleave">
+        <ref name="localityname.attributes"/>
+      </define>
+    </div>
+    <div>
+      <a:documentation> LONG NAME: Administrative Area </a:documentation>
+      <define name="administrativearea.content">
+        <zeroOrMore>
+          <ref name="words.cnt"/>
+        </zeroOrMore>
+      </define>
+      <define name="administrativearea.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
+        <ref name="univ-atts"/>
+      </define>
+      <define name="administrativearea.element">
+        <element name="administrativearea" dita:longName="Administrative Area">
+          <a:documentation><![CDATA[The <administrativearea> element contains information about a county, state, or province.
+    Category: xNAL elements
+  ]]></a:documentation>
+          <ref name="administrativearea.attlist"/>
+          <ref name="administrativearea.content"/>
+        </element>
+      </define>
+      <define name="administrativearea.attlist" combine="interleave">
+        <ref name="administrativearea.attributes"/>
+      </define>
+    </div>
+    <div>
+      <a:documentation> LONG NAME: Thoroughfare </a:documentation>
+      <define name="thoroughfare.content">
+        <zeroOrMore>
+          <ref name="words.cnt"/>
+        </zeroOrMore>
+      </define>
+      <define name="thoroughfare.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
+        <ref name="univ-atts"/>
+      </define>
+      <define name="thoroughfare.element">
+        <element name="thoroughfare" dita:longName="Thoroughfare">
+          <a:documentation><![CDATA[The <thoroughfare> element contains information about the thoroughfare - for example, the street, avenue, or boulevard - on which an address is located.
+    Category: xNAL elements
+  ]]></a:documentation>
+          <ref name="thoroughfare.attlist"/>
+          <ref name="thoroughfare.content"/>
+        </element>
+      </define>
+      <define name="thoroughfare.attlist" combine="interleave">
+        <ref name="thoroughfare.attributes"/>
+      </define>
+    </div>
+    <div>
+      <a:documentation> LONG NAME: Postal Code </a:documentation>
+      <define name="postalcode.content">
+        <zeroOrMore>
+          <choice>
+            <text/>
+            <ref name="keyword"/>
+            <ref name="text" dita:since="1.3"/>
+          </choice>
+        </zeroOrMore>
+      </define>
+      <define name="postalcode.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
+        <ref name="univ-atts"/>
+      </define>
+      <define name="postalcode.element">
+        <element name="postalcode" dita:longName="Postal Code">
+          <a:documentation><![CDATA[The <postalcode> element contains information about the postal code or the ZIP code.
+    Category: xNAL elements
+  ]]></a:documentation>
+          <ref name="postalcode.attlist"/>
+          <ref name="postalcode.content"/>
+        </element>
+      </define>
+      <define name="postalcode.attlist" combine="interleave">
+        <ref name="postalcode.attributes"/>
+      </define>
+    </div>
+    <div>
+      <a:documentation> LONG NAME: Country </a:documentation>
+      <define name="country.content">
+        <zeroOrMore>
+          <choice>
+            <text/>
+            <ref name="keyword"/>
+            <ref name="text" dita:since="1.3"/>
+          </choice>
+        </zeroOrMore>
+      </define>
+      <define name="country.attributes">
+        <optional>
+          <attribute name="keyref"/>
+        </optional>
+        <ref name="univ-atts"/>
+      </define>
+      <define name="country.element">
+        <element name="country" dita:longName="Country">
+          <a:documentation><![CDATA[The <country> element contains the name of a country.
+    Category: xNAL elements
+  ]]></a:documentation>
+          <ref name="country.attlist"/>
+          <ref name="country.content"/>
+        </element>
+      </define>
+      <define name="country.attlist" combine="interleave">
+        <ref name="country.attributes"/>
+      </define>
+    </div>
+    <div>
+      <a:documentation> LONG NAME: Person Information </a:documentation>
+      <define name="personinfo.content">
+        <optional>
+          <ref name="namedetails"/>
+        </optional>
+        <optional>
+          <ref name="addressdetails"/>
+        </optional>
+        <optional>
+          <ref name="contactnumbers"/>
+        </optional>
+        <optional>
+          <ref name="emailaddresses"/>
+        </optional>
+      </define>
+      <define name="personinfo.attributes">
+        <ref name="data-element-atts"/>
+      </define>
+      <define name="personinfo.element">
+        <element name="personinfo" dita:longName="Person Information">
+          <a:documentation><![CDATA[The <personinfo> element is a wrapper containing all relevant data about a person, including name, address, and contact information.
+    Category: xNAL elements
+  ]]></a:documentation>
+          <ref name="personinfo.attlist"/>
+          <ref name="personinfo.content"/>
+        </element>
+      </define>
+      <define name="personinfo.attlist" combine="interleave">
+        <ref name="personinfo.attributes"/>
+      </define>
+    </div>
+    <div>
+      <a:documentation> LONG NAME: Organization Information </a:documentation>
+      <define name="organizationinfo.content">
+        <optional>
+          <ref name="namedetails"/>
+        </optional>
+        <optional>
+          <ref name="addressdetails"/>
+        </optional>
+        <optional>
+          <ref name="contactnumbers"/>
+        </optional>
+        <optional>
+          <ref name="emailaddresses"/>
+        </optional>
+        <optional>
+          <ref name="urls"/>
+        </optional>
+      </define>
+      <define name="organizationinfo.attributes">
+        <ref name="data-element-atts"/>
+      </define>
+      <define name="organizationinfo.element">
+        <element name="organizationinfo" dita:longName="Organization Information">
+          <a:documentation><![CDATA[The <organizationinfo> element contains detailed information about an authoring organization.
+    Category: xNAL elements
+  ]]></a:documentation>
+          <ref name="organizationinfo.attlist"/>
+          <ref name="organizationinfo.content"/>
+        </element>
+      </define>
+      <define name="organizationinfo.attlist" combine="interleave">
+        <ref name="organizationinfo.attributes"/>
+      </define>
+    </div>
+    <div>
+      <a:documentation> LONG NAME: Contact Numbers </a:documentation>
+      <define name="contactnumbers.content">
+        <zeroOrMore>
+          <ref name="contactnumber"/>
+        </zeroOrMore>
+      </define>
+      <define name="contactnumbers.attributes">
+        <ref name="data-element-atts"/>
+      </define>
+      <define name="contactnumbers.element">
+        <element name="contactnumbers" dita:longName="Contact Numbers">
+          <a:documentation><![CDATA[The <contactnumbers> element contains a list of telephone and fax numbers.
+    Category: xNAL elements
+  ]]></a:documentation>
+          <ref name="contactnumbers.attlist"/>
+          <ref name="contactnumbers.content"/>
+        </element>
+      </define>
+      <define name="contactnumbers.attlist" combine="interleave">
+        <ref name="contactnumbers.attributes"/>
+      </define>
+    </div>
+    <div>
+      <a:documentation> LONG NAME: Contact Number </a:documentation>
+      <a:documentation> Note: set the type of number using @type </a:documentation>
+      <define name="contactnumber.content">
+        <zeroOrMore>
+          <choice>
+            <text/>
+            <ref name="keyword"/>
+            <ref name="text" dita:since="1.3"/>
+          </choice>
+        </zeroOrMore>
+      </define>
+      <define name="contactnumber.attributes">
+        <ref name="data-element-atts"/>
+      </define>
+      <define name="contactnumber.element">
+        <element name="contactnumber" dita:longName="Contact Number">
+          <a:documentation><![CDATA[A <contactnumber> element contains a telephone number.
+    Category: xNAL elements
+  ]]></a:documentation>
+          <ref name="contactnumber.attlist"/>
+          <ref name="contactnumber.content"/>
+        </element>
+      </define>
+      <define name="contactnumber.attlist" combine="interleave">
+        <ref name="contactnumber.attributes"/>
+      </define>
+    </div>
+    <div>
+      <a:documentation> LONG NAME: Email Addresses </a:documentation>
+      <define name="emailaddresses.content">
+        <zeroOrMore>
+          <ref name="emailaddress"/>
+        </zeroOrMore>
+      </define>
+      <define name="emailaddresses.attributes">
+        <ref name="data-element-atts"/>
+      </define>
+      <define name="emailaddresses.element">
+        <element name="emailaddresses" dita:longName="Email Addresses">
+          <a:documentation><![CDATA[The <emailaddress> element contains a list of e-mail addresses.
+    Category: xNAL elements
+  ]]></a:documentation>
+          <ref name="emailaddresses.attlist"/>
+          <ref name="emailaddresses.content"/>
+        </element>
+      </define>
+      <define name="emailaddresses.attlist" combine="interleave">
+        <ref name="emailaddresses.attributes"/>
+      </define>
+    </div>
+    <div>
+      <a:documentation> LONG NAME: Email Address </a:documentation>
+      <define name="emailaddress.content">
+        <zeroOrMore>
+          <ref name="words.cnt"/>
+        </zeroOrMore>
+      </define>
+      <define name="emailaddress.attributes">
+        <ref name="data-element-atts"/>
+      </define>
+      <define name="emailaddress.element">
+        <element name="emailaddress" dita:longName="Email Address">
+          <a:documentation><![CDATA[The <emailaddress> element contains an e-mail address.
+    Category: xNAL elements
+  ]]></a:documentation>
+          <ref name="emailaddress.attlist"/>
+          <ref name="emailaddress.content"/>
+        </element>
+      </define>
+      <define name="emailaddress.attlist" combine="interleave">
+        <ref name="emailaddress.attributes"/>
+      </define>
+    </div>
+    <div>
+      <a:documentation> LONG NAME: URLs </a:documentation>
+      <define name="urls.content">
+        <zeroOrMore>
+          <ref name="url"/>
+        </zeroOrMore>
+      </define>
+      <define name="urls.attributes">
+        <ref name="data-element-atts"/>
+      </define>
+      <define name="urls.element">
+        <element name="urls" dita:longName="URLs">
+          <a:documentation><![CDATA[The <urls> element contains a list of Uniform Resource Locators (URLs).
+    Category: xNAL elements
+  ]]></a:documentation>
+          <ref name="urls.attlist"/>
+          <ref name="urls.content"/>
+        </element>
+      </define>
+      <define name="urls.attlist" combine="interleave">
+        <ref name="urls.attributes"/>
+      </define>
+    </div>
+    <div>
+      <a:documentation> LONG NAME: URL </a:documentation>
+      <define name="url.content">
+        <zeroOrMore>
+          <ref name="words.cnt"/>
+        </zeroOrMore>
+      </define>
+      <define name="url.attributes">
+        <ref name="data-element-atts"/>
+      </define>
+      <define name="url.element">
+        <element name="url" dita:longName="URL">
+          <a:documentation><![CDATA[The <url> element contains a Uniform Resource Locator (URL).
+    Category: xNAL elements
+  ]]></a:documentation>
+          <ref name="url.attlist"/>
+          <ref name="url.content"/>
+        </element>
+      </define>
+      <define name="url.attlist" combine="interleave">
+        <ref name="url.attributes"/>
+      </define>
+    </div>
+  </div>
+  <div>
+    <a:documentation> SPECIALIZATION ATTRIBUTE DECLARATIONS </a:documentation>
+    <define name="addressdetails.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="+ topic/ph xnal-d/addressdetails "/>
+      </optional>
+    </define>
+    <define name="administrativearea.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="+ topic/ph xnal-d/administrativearea "/>
+      </optional>
+    </define>
+    <define name="authorinformation.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="+ topic/author xnal-d/authorinformation "/>
+      </optional>
+    </define>
+    <define name="contactnumber.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="+ topic/data xnal-d/contactnumber "/>
+      </optional>
+    </define>
+    <define name="contactnumbers.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="+ topic/data xnal-d/contactnumbers "/>
+      </optional>
+    </define>
+    <define name="country.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="+ topic/ph xnal-d/country "/>
+      </optional>
+    </define>
+    <define name="emailaddress.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="+ topic/data xnal-d/emailaddress "/>
+      </optional>
+    </define>
+    <define name="emailaddresses.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="+ topic/data xnal-d/emailaddresses "/>
+      </optional>
+    </define>
+    <define name="firstname.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="+ topic/data xnal-d/firstname "/>
+      </optional>
+    </define>
+    <define name="generationidentifier.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="+ topic/data xnal-d/generationidentifier "/>
+      </optional>
+    </define>
+    <define name="honorific.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="+ topic/data xnal-d/honorific "/>
+      </optional>
+    </define>
+    <define name="lastname.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="+ topic/data xnal-d/lastname "/>
+      </optional>
+    </define>
+    <define name="locality.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="+ topic/ph xnal-d/locality "/>
+      </optional>
+    </define>
+    <define name="localityname.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="+ topic/ph xnal-d/localityname "/>
+      </optional>
+    </define>
+    <define name="middlename.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="+ topic/data xnal-d/middlename "/>
+      </optional>
+    </define>
+    <define name="namedetails.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="+ topic/data xnal-d/namedetails "/>
+      </optional>
+    </define>
+    <define name="organizationinfo.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="+ topic/data xnal-d/organizationinfo "/>
+      </optional>
+    </define>
+    <define name="organizationname.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="+ topic/ph xnal-d/organizationname "/>
+      </optional>
+    </define>
+    <define name="organizationnamedetails.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="+ topic/ph xnal-d/organizationnamedetails "/>
+      </optional>
+    </define>
+    <define name="otherinfo.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="+ topic/data xnal-d/otherinfo "/>
+      </optional>
+    </define>
+    <define name="personinfo.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="+ topic/data xnal-d/personinfo "/>
+      </optional>
+    </define>
+    <define name="personname.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="+ topic/data xnal-d/personname "/>
+      </optional>
+    </define>
+    <define name="postalcode.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="+ topic/ph xnal-d/postalcode "/>
+      </optional>
+    </define>
+    <define name="thoroughfare.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="+ topic/ph xnal-d/thoroughfare "/>
+      </optional>
+    </define>
+    <define name="url.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="+ topic/data xnal-d/url "/>
+      </optional>
+    </define>
+    <define name="urls.attlist" combine="interleave">
+      <optional>
+        <attribute name="class" a:defaultValue="+ topic/data xnal-d/urls "/>
+      </optional>
+    </define>
+  </div>
+</grammar>

--- a/src/xnal/specification/README.md
+++ b/src/xnal/specification/README.md
@@ -1,0 +1,8 @@
+# xNAL domain
+
+This directory contains specification documents related to 
+the xNAL vocabulary. These are provided for reference only; they
+contain the latest specification files as of the time this domain
+was withdrawn from the specification. The content will not build 
+on its own (it reliese on keys from the technical content specification),
+but may be useful for the examples and element descriptions.

--- a/src/xnal/specification/containers/xnal-d.dita
+++ b/src/xnal/specification/containers/xnal-d.dita
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="xnald" xml:lang="en-us">
+<title>xNAL domain</title>
+<shortdesc>The xNAL domain elements represent a subset of the Extensible
+Name and Address Standard. It is used to encode information about
+the author or authors of DITA information. The domain can be included
+in any DITA document type shell that requires additional metadata
+for names and addresses, although the implementations provided by
+OASIS only include it in the bookmap document type.</shortdesc>
+<prolog><metadata>
+<keywords><indexterm>Domains elements<indexterm>xNAL domain</indexterm></indexterm>
+<indexterm>xNAL elements</indexterm></keywords>
+</metadata></prolog>
+ <refbody>
+  <section id="section_zgd_twj_spb">
+   <draft-comment author="robander" time="24 may 2021">General question about elements in this
+     section:<ul id="ul_jpg_vwj_spb">
+     <li>Should many of the examples just be referring to the example in &lt;authorinformation>,
+      rather than repeating? If yes - need to make the update; if no - need to add prose around the
+      samples, and bold the relevant elements.</li>
+     <li>Short descriptions often refer to "the person" or "the author" or "the organization" but
+      that rarely makes sense in the context of a single element definition. Should it be a person /
+      an author / etc? See <xref href="../technicalContent/firstname.dita"/> for specific
+      example</li>
+    </ul></draft-comment>
+   <p/>
+  </section>
+ </refbody>
+</reference>
+

--- a/src/xnal/specification/technicalContent/addressdetails.dita
+++ b/src/xnal/specification/technicalContent/addressdetails.dita
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="addressdetails" xml:lang="en-us">
+  <title><xmlelement>addressdetails</xmlelement></title>
+  <shortdesc>The <xmlelement>addressdetails</xmlelement> element specifies information about the
+    address of an author or authoring group.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm><xmlelement>addressdetails</xmlelement><indexterm>xNAL
+              elements<xmlelement>addressdetails</xmlelement></indexterm></indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <refbody>
+    <section id="specialization-hierarchy"
+        ><title>Specialization hierarchy</title>
+      <p>The <xmlelement>addressdetails</xmlelement> element is specialized from
+          <xmlelement>ph</xmlelement>. It is defined in the XNAL domain module.</p></section>
+    <section id="attributes"><title>Attributes</title>
+      <p conkeyref="reuse-attributes/universal-keyref"/>
+    </section>
+    <example id="example" otherprops="examples"
+      ><title>Example</title>
+      <draft-comment author="robander" time="24 May 2021">Can this and most of the XNAL examples
+        just be a link to authorinformation?</draft-comment>
+      <p>The following code sample shows how the <xmlelement>addressdetails</xmlelement> element can
+        be used to provide detailed information about the address of an author:</p>
+      <codeblock id="codeblock_xdt_rr2_nwb">&lt;bookmeta>
+ &lt;authorinformation&gt;
+  &lt;personinfo&gt;
+   &lt;namedetails&gt;&lt;personname&gt;
+    &lt;firstname&gt;Derek&lt;/firstname&gt;
+    &lt;middlename&gt;L.&lt;/middlename&gt;
+    &lt;lastname&gt;Singleton&lt;/lastname&gt;
+    &lt;generationidentifier&gt;Jr.&lt;/generationidentifier&gt;
+    &lt;otherinfo&gt;noted psychologist&lt;/otherinfo&gt;
+  &lt;/personname&gt;&lt;/namedetails&gt;
+  <b>&lt;addressdetails&gt;</b>
+    &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+    &lt;locality&gt;Emerald City&lt;/locality&gt;
+    &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+    &lt;country&gt;USA&lt;/country&gt;
+  <b>&lt;/addressdetails&gt;</b>
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+  &lt;/personinfo&gt;
+ &lt;/authorinformation&gt;
+&lt;/bookmeta></codeblock>
+    </example>
+  </refbody>
+</reference>

--- a/src/xnal/specification/technicalContent/administrativearea.dita
+++ b/src/xnal/specification/technicalContent/administrativearea.dita
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="administrativearea" xml:lang="en-us">
+   <title><xmlelement>administrativearea</xmlelement></title>
+   <shortdesc>The <xmlelement>administrativearea</xmlelement> element specifies information about a
+      county, state, or province.</shortdesc>
+   <prolog>
+      <metadata>
+         <keywords>
+            <indexterm>xNAL
+                  elements<indexterm><xmlelement>administrativearea</xmlelement></indexterm></indexterm>
+            <indexterm><xmlelement>administrativearea</xmlelement></indexterm>
+         </keywords>
+      </metadata>
+   </prolog>
+   <refbody>
+      <section id="specialization-hierarchy"
+            ><title>Specialization hierarchy</title>
+         <p>The <xmlelement>administrativearea</xmlelement> element is specialized from
+               <xmlelement>ph</xmlelement>. It is defined in the XNAL domain module.</p></section>
+      <section id="attributes"><title>Attributes</title>
+         <p conkeyref="reuse-attributes/universal-keyref"/>
+         <p>The following code sample shows how the <xmlelement>administrativearea</xmlelement>
+            element can be used to provide detailed information about a county, state, or
+            province:</p>
+      </section>
+      <example id="example" otherprops="examples"><title>Example</title>
+         <codeblock id="codeblock_xdt_rr2_nwb">&lt;bookmeta>
+ &lt;authorinformation&gt;
+  &lt;personinfo&gt;
+   &lt;namedetails&gt;&lt;personname&gt;
+     &lt;firstname&gt;Derek&lt;/firstname&gt;
+     &lt;middlename&gt;L.&lt;/middlename&gt;
+     &lt;lastname&gt;Singleton&lt;/lastname&gt;
+     &lt;generationidentifier&gt;Jr.&lt;/generationidentifier&gt;
+     &lt;otherinfo&gt;noted psychologist&lt;/otherinfo&gt;
+   &lt;/personname&gt;&lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+     &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+     &lt;locality&gt;Emerald City&lt;/locality&gt;
+     <b>&lt;administrativearea&gt;</b>Kansas<b>&lt;/administrativearea&gt;</b>
+     &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+  &lt;/personinfo&gt;
+ &lt;/authorinformation&gt;
+&lt;/bookmeta></codeblock></example>
+   </refbody>
+</reference>

--- a/src/xnal/specification/technicalContent/authorinformation.dita
+++ b/src/xnal/specification/technicalContent/authorinformation.dita
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="authorinformation" xml:lang="en-us">
+  <title><xmlelement>authorinformation</xmlelement></title>
+  <shortdesc>The <xmlelement>authorinformation</xmlelement> element specifies detailed information
+    about an author or authoring organization.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm><xmlelement>authorinformation</xmlelement></indexterm>
+        <indexterm>xNAL
+          elements<indexterm><xmlelement>authorinformation</xmlelement></indexterm></indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <refbody>
+    <section id="specialization-hierarchy"
+        ><title>Specialization hierarchy</title>
+      <p>The <xmlelement>authorinformation</xmlelement> element is specialized from
+          <xmlelement>author</xmlelement>. It is defined in the XNAL domain module.</p></section>
+    <section id="attributes"><title>Attributes</title><div conkeyref="reuse-attributes/author-attributes"/></section>
+    <example id="example" otherprops="examples"
+      ><title>Example</title>
+      <p>The following code sample shows how the <xmlelement>authorinformation</xmlelement> element
+        can be used to provide detailed information about an author:</p>
+      <codeblock>&lt;bookmeta>
+ <b>&lt;authorinformation&gt;</b>
+  &lt;personinfo&gt;
+   &lt;namedetails&gt;&lt;personname&gt;
+     &lt;firstname&gt;Derek&lt;/firstname&gt;
+     &lt;middlename&gt;L.&lt;/middlename&gt;
+     &lt;lastname&gt;Singleton&lt;/lastname&gt;
+     &lt;generationidentifier&gt;Jr.&lt;/generationidentifier&gt;
+     &lt;otherinfo&gt;noted psychologist&lt;/otherinfo&gt;
+   &lt;/personname&gt;&lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+     &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+     &lt;locality&gt;Emerald City&lt;/locality&gt;
+     &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+     &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+  &lt;/personinfo&gt;
+ <b>&lt;/authorinformation&gt;</b>
+&lt;/bookmeta></codeblock></example>
+  </refbody>
+</reference>

--- a/src/xnal/specification/technicalContent/contactnumber.dita
+++ b/src/xnal/specification/technicalContent/contactnumber.dita
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="contactnumber" xml:lang="en-us">
+  <title><xmlelement>contactnumber</xmlelement></title>
+  <shortdesc>The <xmlelement>contactnumber</xmlelement> element specifies a contact number for an
+    author or authoring organization, such as a telephone number.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>contactnumber<indexterm>xNAL
+            elements<indexterm>contactnumber</indexterm></indexterm></indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <refbody>
+    <section id="specialization-hierarchy">
+      <title>Specialization hierarchy</title>
+      <p>The <xmlelement>contactnumber</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
+    </section>
+    <section id="attributes">
+      <title>Attributes</title>
+      <p conkeyref="reuse-attributes/data-link-universal-outputclass"/>
+    </section>
+    <example id="example" otherprops="examples">
+      <title>Example</title>
+      <p>The following code sample shows how the <xmlelement>contactnumber</xmlelement> element can
+        be used to provide a contact number for an author or authoring organization, such as a
+        telephone number:</p>
+      <codeblock id="codeblock_xdt_rr2_nwb">&lt;bookmeta>
+ &lt;authorinformation&gt;
+  &lt;personinfo&gt;
+   &lt;namedetails&gt;&lt;personname&gt;
+     &lt;firstname&gt;Derek&lt;/firstname&gt;
+     &lt;middlename&gt;L.&lt;/middlename&gt;
+     &lt;lastname&gt;Singleton&lt;/lastname&gt;
+     &lt;generationidentifier&gt;Jr.&lt;/generationidentifier&gt;
+     &lt;otherinfo&gt;noted psychologist&lt;/otherinfo&gt;
+   &lt;/personname&gt;&lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+     &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+     &lt;locality&gt;Emerald City&lt;/locality&gt;
+     &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+     &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;<b>&lt;contactnumber&gt;</b>123-555-4678<b>&lt;/contactnumber&gt;</b>&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+  &lt;/personinfo&gt;
+ &lt;/authorinformation&gt;
+&lt;/bookmeta></codeblock></example>
+  </refbody>
+</reference>

--- a/src/xnal/specification/technicalContent/contactnumbers.dita
+++ b/src/xnal/specification/technicalContent/contactnumbers.dita
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="contactnumbers" xml:lang="en-us">
+  <title><xmlelement>contactnumbers</xmlelement></title>
+  <shortdesc>The <xmlelement>contactnumbers</xmlelement> element provides a list of contact
+    numbers.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>contactnumbers<indexterm>xNAL
+            elements<indexterm>contactnumbers</indexterm></indexterm></indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <refbody>
+    <section id="specialization-hierarchy">
+      <title>Specialization hierarchy</title>
+      <p>The <xmlelement>contactnumbers</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
+    </section>
+    <section id="attributes">
+      <title>Attributes</title>
+      <p conkeyref="reuse-attributes/data-link-universal-outputclass"/>
+    </section>
+    <example id="example" otherprops="examples">
+      <title>Example</title>
+      <p>The following code sample shows how the <xmlelement>contactnumbers</xmlelement> element can
+        be used to provide a list of contact numbers:</p>
+      <codeblock id="codeblock_xdt_rr2_nwb">&lt;bookmeta>
+ &lt;authorinformation&gt;
+  &lt;personinfo&gt;
+   &lt;namedetails&gt;&lt;personname&gt;
+     &lt;firstname&gt;Derek&lt;/firstname&gt;
+     &lt;middlename&gt;L.&lt;/middlename&gt;
+     &lt;lastname&gt;Singleton&lt;/lastname&gt;
+     &lt;generationidentifier&gt;Jr.&lt;/generationidentifier&gt;
+     &lt;otherinfo&gt;noted psychologist&lt;/otherinfo&gt;
+   &lt;/personname&gt;&lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+     &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+     &lt;locality&gt;Emerald City&lt;/locality&gt;
+     &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+     &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   <b>&lt;contactnumbers&gt;</b>&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;<b>&lt;/contactnumbers&gt;</b>
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+  &lt;/personinfo&gt;
+ &lt;/authorinformation&gt;
+&lt;/bookmeta></codeblock></example>
+  </refbody>
+</reference>

--- a/src/xnal/specification/technicalContent/country.dita
+++ b/src/xnal/specification/technicalContent/country.dita
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="country" xml:lang="en-us">
+  <title><xmlelement>country</xmlelement></title>
+  <shortdesc>The <xmlelement>country</xmlelement> element specifies the name of a
+    country.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>country<indexterm>xNAL
+          elements<indexterm>country</indexterm></indexterm></indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <refbody>
+    <section id="specialization-hierarchy">
+      <title>Specialization hierarchy</title>
+      <p>The <xmlelement>country</xmlelement> element is specialized from
+          <xmlelement>ph</xmlelement>. It is defined in the XNAL domain module.</p>
+    </section>
+    <section id="attributes">
+      <title>Attributes</title>
+      <p conkeyref="reuse-attributes/universal-keyref"/>
+    </section>
+    <example id="example" otherprops="examples">
+      <title>Example</title>
+      <p>The following code sample shows how the <xmlelement>country</xmlelement> element can be
+        used to specify the name of a country:</p>
+      <codeblock id="codeblock_xdt_rr2_nwb">&lt;bookmeta>
+ &lt;authorinformation&gt;
+  &lt;personinfo&gt;
+   &lt;namedetails&gt;&lt;personname&gt;
+     &lt;firstname&gt;Derek&lt;/firstname&gt;
+     &lt;middlename&gt;L.&lt;/middlename&gt;
+     &lt;lastname&gt;Singleton&lt;/lastname&gt;
+     &lt;generationidentifier&gt;Jr.&lt;/generationidentifier&gt;
+     &lt;otherinfo&gt;noted psychologist&lt;/otherinfo&gt;
+   &lt;/personname&gt;&lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+     &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+     &lt;locality&gt;Emerald City&lt;/locality&gt;
+     &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+     <b>&lt;country&gt;</b>USA<b>&lt;/country&gt;</b>
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+  &lt;/personinfo&gt;
+ &lt;/authorinformation&gt;
+&lt;/bookmeta></codeblock></example>
+  </refbody>
+</reference>

--- a/src/xnal/specification/technicalContent/emailaddress.dita
+++ b/src/xnal/specification/technicalContent/emailaddress.dita
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="emailaddress" xml:lang="en-us">
+  <title><xmlelement>emailaddress</xmlelement></title>
+  <shortdesc>The <xmlelement>emailaddress</xmlelement> element specifies an e-mail address for an
+    author or authoring organization.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>xNAL elements<indexterm>emailaddress</indexterm></indexterm>
+        <indexterm>emailaddress</indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <refbody>
+    <section id="specialization-hierarchy">
+      <title>Specialization hierarchy</title>
+      <p>The <xmlelement>emailaddress</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
+    </section>
+    <section id="attributes">
+      <title>Attributes</title>
+      <p conkeyref="reuse-attributes/data-link-universal-outputclass"/>
+    </section>
+    <example id="example" otherprops="examples">
+      <title>Example</title>
+      <p>The following code sample shows how the <xmlelement>emailaddress</xmlelement> element can
+        be used to provide an email address for an author or authoring organization:</p>
+      <codeblock id="codeblock_xdt_rr2_nwb">&lt;bookmeta>
+ &lt;authorinformation&gt;
+  &lt;personinfo&gt;
+   &lt;namedetails&gt;&lt;personname&gt;
+     &lt;firstname&gt;Derek&lt;/firstname&gt;
+     &lt;middlename&gt;L.&lt;/middlename&gt;
+     &lt;lastname&gt;Singleton&lt;/lastname&gt;
+     &lt;generationidentifier&gt;Jr.&lt;/generationidentifier&gt;
+     &lt;otherinfo&gt;noted psychologist&lt;/otherinfo&gt;
+   &lt;/personname&gt;&lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+     &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+     &lt;locality&gt;Emerald City&lt;/locality&gt;
+     &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+     &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;<b>&lt;emailaddress&gt;</b>wizard@example.org<b>&lt;/emailaddress&gt;</b>&lt;/emailaddresses&gt;
+  &lt;/personinfo&gt;
+ &lt;/authorinformation&gt;
+&lt;/bookmeta></codeblock></example>
+  </refbody>
+</reference>

--- a/src/xnal/specification/technicalContent/emailaddresses.dita
+++ b/src/xnal/specification/technicalContent/emailaddresses.dita
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="emailaddresses" xml:lang="en-us">
+  <title><xmlelement>emailaddresses</xmlelement></title>
+  <shortdesc>The <xmlelement>emailaddresses</xmlelement> element provides one or more e-mail
+    addresses for an author or authoring organization.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>xNAL elements<indexterm>emailaddresses</indexterm></indexterm>
+        <indexterm>emailaddresses</indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <refbody>
+    <section id="specialization-hierarchy">
+      <title>Specialization hierarchy</title>
+      <p>The <xmlelement>emailaddresses</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
+    </section>
+    <section id="attributes">
+      <title>Attributes</title>
+      <p conkeyref="reuse-attributes/data-link-universal-outputclass"/>
+    </section>
+    <example id="example" otherprops="examples">
+      <title>Example</title>
+      <p>The following code sample shows how the <xmlelement>emailaddresses</xmlelement> element can
+        be used to provide one or more email addresses for an author or authoring organization:</p>
+      <codeblock id="codeblock_xdt_rr2_nwb">&lt;bookmeta>
+ &lt;authorinformation&gt;
+  &lt;personinfo&gt;
+   &lt;namedetails&gt;&lt;personname&gt;
+     &lt;firstname&gt;Derek&lt;/firstname&gt;
+     &lt;middlename&gt;L.&lt;/middlename&gt;
+     &lt;lastname&gt;Singleton&lt;/lastname&gt;
+     &lt;generationidentifier&gt;Jr.&lt;/generationidentifier&gt;
+     &lt;otherinfo&gt;noted psychologist&lt;/otherinfo&gt;
+   &lt;/personname&gt;&lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+     &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+     &lt;locality&gt;Emerald City&lt;/locality&gt;
+     &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+     &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   <b>&lt;emailaddresses&gt;</b>&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;<b>&lt;/emailaddresses&gt;</b>
+  &lt;/personinfo&gt;
+ &lt;/authorinformation&gt;
+&lt;/bookmeta></codeblock></example>
+  </refbody>
+</reference>

--- a/src/xnal/specification/technicalContent/firstname.dita
+++ b/src/xnal/specification/technicalContent/firstname.dita
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="firstname" xml:lang="en-us">
+  <title><xmlelement>firstname</xmlelement></title>
+  <shortdesc>The <xmlelement>firstname</xmlelement> element specifies the first name of an
+      author.<draft-comment author="robander" time="24 May 2021">Question about all of these …
+      should it be "the person" or "a person"? "The person" only seems to make sense if we are
+      already talking about a person, but the short description for this element does not have that
+      context. It seems like when defining the element on its own, it should be "a
+      person".</draft-comment></shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>firstname<indexterm>xNAL
+          elements<indexterm>firstname</indexterm></indexterm></indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <refbody>
+    <section id="specialization-hierarchy">
+      <title>Specialization hierarchy</title>
+      <p>The <xmlelement>firstname</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
+    </section>
+    <section id="attributes">
+      <title>Attributes</title>
+      <p conkeyref="reuse-attributes/data-link-universal-outputclass"/>
+    </section>
+    <example id="example" otherprops="examples">
+      <title>Example</title>
+      <p>The following code sample shows how the <xmlelement>firstname</xmlelement> element can be
+        used to specify the first name of an author:</p>
+      <codeblock id="codeblock_xdt_rr2_nwb">&lt;bookmeta>
+ &lt;authorinformation&gt;
+  &lt;personinfo&gt;
+   &lt;namedetails&gt;&lt;personname&gt;
+     <b>&lt;firstname</b>&gt;Derek<b>&lt;/firstname&gt;</b>
+     &lt;middlename&gt;L.&lt;/middlename&gt;
+     &lt;lastname&gt;Singleton&lt;/lastname&gt;
+     &lt;generationidentifier&gt;Jr.&lt;/generationidentifier&gt;
+     &lt;otherinfo&gt;noted psychologist&lt;/otherinfo&gt;
+   &lt;/personname&gt;&lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+     &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+     &lt;locality&gt;Emerald City&lt;/locality&gt;
+     &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+     &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+  &lt;/personinfo&gt;
+ &lt;/authorinformation&gt;
+&lt;/bookmeta></codeblock></example>
+  </refbody>
+</reference>

--- a/src/xnal/specification/technicalContent/generationidentifier.dita
+++ b/src/xnal/specification/technicalContent/generationidentifier.dita
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="generationidentifier" xml:lang="en-us">
+  <title><xmlelement>generationidentifier</xmlelement></title>
+  <shortdesc>The <xmlelement>generationidentifier</xmlelement> element specifies information about
+    the generation of an author's name, for example Jr, III, or VIII.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>generationidentifier<indexterm>xNAL
+              elements<indexterm>generationidentifier</indexterm></indexterm></indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <refbody>
+    <section id="specialization-hierarchy">
+      <title>Specialization hierarchy</title>
+      <p>The <xmlelement>generationidentifier</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
+    </section>
+    <section id="attributes">
+      <title>Attributes</title>
+      <p conkeyref="reuse-attributes/data-link-universal-outputclass"/>
+    </section>
+    <example id="example" otherprops="examples">
+      <title>Example</title>
+      <p>The following code sample shows how the <xmlelement>generationidentifier</xmlelement>
+        element can be used to provide information about the generation of an author's name:</p>
+      <codeblock id="codeblock_xdt_rr2_nwb">&lt;bookmeta>
+ &lt;authorinformation&gt;
+  &lt;personinfo&gt;
+   &lt;namedetails&gt;&lt;personname&gt;
+     &lt;firstname&gt;Derek&lt;/firstname&gt;
+     &lt;middlename&gt;L.&lt;/middlename&gt;
+     &lt;lastname&gt;Singleton&lt;/lastname&gt;
+        <b>&lt;generationidentifier&gt;</b>Jr.<b>&lt;/generationidentifier&gt;</b>
+     &lt;otherinfo&gt;noted psychologist&lt;/otherinfo&gt;
+   &lt;/personname&gt;&lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+     &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+     &lt;locality&gt;Emerald City&lt;/locality&gt;
+     &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+     &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+  &lt;/personinfo&gt;
+ &lt;/authorinformation&gt;
+&lt;/bookmeta></codeblock></example>
+  </refbody>
+</reference>

--- a/src/xnal/specification/technicalContent/honorific.dita
+++ b/src/xnal/specification/technicalContent/honorific.dita
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="honorific" xml:lang="en-us">
+  <title><xmlelement>honorific</xmlelement></title>
+  <shortdesc>The <xmlelement>honorific</xmlelement> element specifies an author's title, such as
+    Dr., Mr., or Ms..</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>honorific<indexterm>xNAL
+          elements<indexterm>honorific</indexterm></indexterm></indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <refbody>
+    <section id="specialization-hierarchy">
+      <title>Specialization hierarchy</title>
+      <p>The <xmlelement>honorific</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
+    </section>
+    <section id="attributes">
+      <title>Attributes</title>
+      <p conkeyref="reuse-attributes/data-link-universal-outputclass"/>
+    </section>
+    <example id="example" otherprops="examples">
+      <title>Example</title>
+      <p>The following code sample shows how the <xmlelement>honorific</xmlelement> element can be
+        used to specify a title for an author:</p>
+      <codeblock id="codeblock_xdt_rr2_nwb">&lt;bookmeta>
+ &lt;authorinformation&gt;
+  &lt;personinfo&gt;
+   &lt;namedetails&gt;&lt;personname&gt;
+     <b>&lt;honorific&gt;</b>Dr.<b>&lt;/honorific&gt;</b>
+     &lt;firstname&gt;Derek&lt;/firstname&gt;
+     &lt;middlename&gt;L.&lt;/middlename&gt;
+     &lt;lastname&gt;Singleton&lt;/lastname&gt;
+     &lt;generationidentifier&gt;Jr.&lt;/generationidentifier&gt;
+     &lt;otherinfo&gt;noted psychologist&lt;/otherinfo&gt;
+   &lt;/personname&gt;&lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+     &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+     &lt;locality&gt;Emerald City&lt;/locality&gt;
+     &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+     &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+  &lt;/personinfo&gt;
+ &lt;/authorinformation&gt;
+&lt;/bookmeta></codeblock></example>
+  </refbody>
+</reference>

--- a/src/xnal/specification/technicalContent/lastname.dita
+++ b/src/xnal/specification/technicalContent/lastname.dita
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="lastname" xml:lang="en-us">
+  <title><xmlelement>lastname</xmlelement></title>
+  <shortdesc>The <xmlelement>lastname</xmlelement> element specifies the last name of an
+    author.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>lastname<indexterm>xNAL
+          elements<indexterm>lastname</indexterm></indexterm></indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <refbody>
+    <section id="specialization-hierarchy">
+      <title>Specialization hierarchy</title>
+      <p>The <xmlelement>lastname</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
+    </section>
+    <section id="attributes">
+      <title>Attributes</title>
+      <p conkeyref="reuse-attributes/data-link-universal-outputclass"/>
+    </section>
+    <example id="example" otherprops="examples">
+      <title>Example</title>
+      <p>The following code sample shows how the <xmlelement>lastname</xmlelement> element can be
+        used to specify the last name of an author:</p>
+      <codeblock id="codeblock_xdt_rr2_nwb">&lt;bookmeta>
+ &lt;authorinformation&gt;
+  &lt;personinfo&gt;
+   &lt;namedetails&gt;&lt;personname&gt;
+     &lt;firstname&gt;Derek&lt;/firstname&gt;
+     &lt;middlename&gt;L.&lt;/middlename&gt;
+     <b>&lt;lastname&gt;</b>Singleton<b>&lt;/lastname&gt;</b>
+     &lt;generationidentifier&gt;Jr.&lt;/generationidentifier&gt;
+     &lt;otherinfo&gt;noted psychologist&lt;/otherinfo&gt;
+   &lt;/personname&gt;&lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+     &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+     &lt;locality&gt;Emerald City&lt;/locality&gt;
+     &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+     &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+  &lt;/personinfo&gt;
+ &lt;/authorinformation&gt;
+&lt;/bookmeta></codeblock></example>
+  </refbody>
+</reference>

--- a/src/xnal/specification/technicalContent/locality.dita
+++ b/src/xnal/specification/technicalContent/locality.dita
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="locality" xml:lang="en-us">
+  <title><xmlelement>locality</xmlelement></title>
+  <shortdesc>The <xmlelement>locality</xmlelement> element specifies information about a city,
+    postal code, or ZIP code.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>xNAL elements<indexterm>locality</indexterm></indexterm>
+        <indexterm>locality</indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <refbody>
+    <section id="specialization-hierarchy">
+      <title>Specialization hierarchy</title>
+      <p>The <xmlelement>locality</xmlelement> element is specialized from
+          <xmlelement>ph</xmlelement>. It is defined in the XNAL domain module.</p>
+    </section>
+    <section id="attributes">
+      <title>Attributes</title>
+      <p conkeyref="reuse-attributes/universal-keyref"/>
+    </section>
+    <example id="example" otherprops="examples">
+      <title>Example</title>
+      <p>The following code sample shows how the <xmlelement>locality</xmlelement> element can be
+        used to provide detailed information about a city, postal code, or ZIP code:</p>
+      <codeblock id="codeblock_xdt_rr2_nwb">&lt;bookmeta>
+ &lt;authorinformation&gt;
+  &lt;personinfo&gt;
+   &lt;namedetails&gt;&lt;personname&gt;
+     &lt;firstname&gt;Derek&lt;/firstname&gt;
+     &lt;middlename&gt;L.&lt;/middlename&gt;
+     &lt;lastname&gt;Singleton&lt;/lastname&gt;
+     &lt;generationidentifier&gt;Jr.&lt;/generationidentifier&gt;
+     &lt;otherinfo&gt;noted psychologist&lt;/otherinfo&gt;
+   &lt;/personname&gt;&lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+     &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+     <b>&lt;locality&gt;</b>Emerald City<b>&lt;/locality&gt;</b>
+     &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+     &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+  &lt;/personinfo&gt;
+ &lt;/authorinformation&gt;
+&lt;/bookmeta></codeblock></example>
+  </refbody>
+</reference>

--- a/src/xnal/specification/technicalContent/localityname.dita
+++ b/src/xnal/specification/technicalContent/localityname.dita
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="localityname" xml:lang="en-us">
+  <title><xmlelement>localityname</xmlelement></title>
+  <shortdesc>The <xmlelement>localityname</xmlelement> element specifies the name of a locality or
+    city.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>xNAL elements<indexterm>localityname</indexterm></indexterm>
+        <indexterm>localityname</indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <refbody>
+    <section id="specialization-hierarchy">
+      <title>Specialization hierarchy</title>
+      <p>The <xmlelement>localityname</xmlelement> element is specialized from
+          <xmlelement>ph</xmlelement>. It is defined in the XNAL domain module.</p>
+    </section>
+    <section id="attributes">
+      <title>Attributes</title>
+      <p conkeyref="reuse-attributes/universal-keyref"/>
+    </section>
+    <example id="example" otherprops="examples">
+      <title>Example</title>
+      <p>The following code sample shows how the <xmlelement>localityname</xmlelement> element can
+        be used to provide information about the name of a locality or city:</p>
+      <codeblock id="codeblock_xdt_rr2_nwb">&lt;bookmeta>
+ &lt;authorinformation&gt;
+  &lt;personinfo&gt;
+   &lt;namedetails&gt;&lt;personname&gt;
+     &lt;firstname&gt;Derek&lt;/firstname&gt;
+     &lt;middlename&gt;L.&lt;/middlename&gt;
+     &lt;lastname&gt;Singleton&lt;/lastname&gt;
+     &lt;generationidentifier&gt;Jr.&lt;/generationidentifier&gt;
+     &lt;otherinfo&gt;noted psychologist&lt;/otherinfo&gt;
+   &lt;/personname&gt;&lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+     &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+     &lt;locality&gt;
+      <b>&lt;localityname&gt;</b>Emerald City<b>&lt;/localityname&gt;</b>
+      &lt;postalcode&gt;66780&lt;/postalcode&gt;
+     &lt;/locality&gt;
+     &lt;locality&gt;Emerald City&lt;/locality&gt;
+     &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+     &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+  &lt;/personinfo&gt;
+ &lt;/authorinformation&gt;
+&lt;/bookmeta></codeblock></example>
+  </refbody>
+</reference>

--- a/src/xnal/specification/technicalContent/middlename.dita
+++ b/src/xnal/specification/technicalContent/middlename.dita
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="middlename" xml:lang="en-us">
+  <title><xmlelement>middlename</xmlelement></title>
+  <shortdesc>The <xmlelement>middlename</xmlelement> element specifies information about the middle
+    name or middle initial of an author.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>middlename<indexterm>xNAL
+          elements<indexterm>middlename</indexterm></indexterm></indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <refbody>
+    <section id="specialization-hierarchy">
+      <title>Specialization hierarchy</title>
+      <p>The <xmlelement>middlename</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
+    </section>
+    <section id="attributes">
+      <title>Attributes</title>
+      <p conkeyref="reuse-attributes/data-link-universal-outputclass"/>
+    </section>
+    <example id="example" otherprops="examples">
+      <title>Example</title>
+      <p>The following code sample shows how the <xmlelement>middlename</xmlelement> element can be
+        used to specify the middle name or middle initial of an author:</p>
+      <codeblock id="codeblock_xdt_rr2_nwb">&lt;bookmeta>
+ &lt;authorinformation&gt;
+  &lt;personinfo&gt;
+   &lt;namedetails&gt;&lt;personname&gt;
+     &lt;firstname&gt;Derek&lt;/firstname&gt;
+     <b>&lt;middlename&gt;</b>L.<b>&lt;/middlename&gt;</b>
+     &lt;lastname&gt;Singleton&lt;/lastname&gt;
+     &lt;generationidentifier&gt;Jr.&lt;/generationidentifier&gt;
+     &lt;otherinfo&gt;noted psychologist&lt;/otherinfo&gt;
+   &lt;/personname&gt;&lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+     &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+     &lt;locality&gt;Emerald City&lt;/locality&gt;
+     &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+     &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+  &lt;/personinfo&gt;
+ &lt;/authorinformation&gt;
+&lt;/bookmeta></codeblock></example>
+  </refbody>
+</reference>

--- a/src/xnal/specification/technicalContent/namedetails.dita
+++ b/src/xnal/specification/technicalContent/namedetails.dita
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="namedetails" xml:lang="en-us">
+  <title><xmlelement>namedetails</xmlelement></title>
+  <shortdesc>The <xmlelement>namedetails</xmlelement> element specifies detailed information about
+    the name of an author or authoring organization.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>namedetails<indexterm>xNAL
+          elements<indexterm>namedetails</indexterm></indexterm></indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <refbody>
+    <section id="specialization-hierarchy">
+      <title>Specialization hierarchy</title>
+      <p>The <xmlelement>namedetails</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
+    </section>
+    <section id="attributes">
+      <title>Attributes</title>
+      <p conkeyref="reuse-attributes/data-link-universal-outputclass"/>
+    </section>
+    <example id="example" otherprops="examples">
+      <title>Example</title>
+      <p>The following code sample shows how the <xmlelement>namedetails</xmlelement> element can be
+        used to specify detailed information about the name of an author or authoring
+        organization:</p>
+      <codeblock id="codeblock_xdt_rr2_nwb">&lt;bookmeta>
+ &lt;authorinformation&gt;
+  &lt;personinfo&gt;
+    <b>&lt;namedetails&gt;</b>
+     &lt;personname&gt;
+      &lt;firstname&gt;Derek&lt;/firstname&gt;
+      &lt;middlename&gt;L.&lt;/middlename&gt;
+      &lt;lastname&gt;Singleton&lt;/lastname&gt;
+      &lt;generationidentifier&gt;Jr.&lt;/generationidentifier&gt;
+      &lt;otherinfo&gt;noted psychologist&lt;/otherinfo&gt;
+     &lt;/personname&gt;
+    <b>&lt;/namedetails&gt;</b>
+   &lt;addressdetails&gt;
+     &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+     &lt;locality&gt;Emerald City&lt;/locality&gt;
+     &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+     &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+  &lt;/personinfo&gt;
+ &lt;/authorinformation&gt;
+&lt;/bookmeta></codeblock></example>
+  </refbody>
+</reference>

--- a/src/xnal/specification/technicalContent/organizationinfo.dita
+++ b/src/xnal/specification/technicalContent/organizationinfo.dita
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="organizationinfo" xml:lang="en-us">
+  <title><xmlelement>organizationinfo</xmlelement></title>
+  <shortdesc>The <xmlelement>organizationinfo</xmlelement> element specifies detailed information
+    about an authoring organization.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>organizationinfo<indexterm>xNAL
+            elements<indexterm>organizationinfo</indexterm></indexterm></indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <refbody>
+    <section id="specialization-hierarchy">
+      <title>Specialization hierarchy</title>
+      <p>The <xmlelement>organizationinfo</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
+    </section>
+    <section id="attributes">
+      <title>Attributes</title>
+      <p conkeyref="reuse-attributes/data-link-universal-outputclass"/>
+    </section>
+    <example id="example" otherprops="examples">
+      <title>Example</title>
+      <p>The following code sample shows how the <xmlelement>organizationinfo</xmlelement> element
+        can be used to provide detailed information about an authoring organization:</p>
+      <codeblock id="codeblock_xdt_rr2_nwb">&lt;bookmeta>
+ &lt;authorinformation&gt;
+ <b>&lt;organizationinfo&gt;</b>
+   &lt;namedetails&gt;
+    &lt;organizationnamedetails&gt;
+     &lt;organizationname&gt;WizardWorks, Inc.&lt;/organizationname&gt;
+     &lt;otherinfo&gt;'Best wizard in Oz'&lt;/otherinfo&gt;
+    &lt;/organizationnamedetails&gt;
+   &lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+    &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+    &lt;locality&gt;Emerald City&lt;/locality&gt;
+    &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+    &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+   &lt;urls&gt;&lt;url&gt;www.wizardworks.example.org&lt;/url&gt;&lt;/urls&gt;
+ <b>&lt;/organizationinfo&gt;</b>
+ &lt;/authorinformation&gt;
+&lt;/bookmeta></codeblock></example>
+  </refbody>
+</reference>

--- a/src/xnal/specification/technicalContent/organizationname.dita
+++ b/src/xnal/specification/technicalContent/organizationname.dita
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="organizationname" xml:lang="en-us">
+  <title><xmlelement>organizationname</xmlelement></title>
+  <shortdesc>The <xmlelement>organizationname</xmlelement> element specifies information about the
+    name of an authoring organization.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>organizationname<indexterm>xNAL
+            elements<indexterm>organizationname</indexterm></indexterm></indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <refbody>
+    <section id="specialization-hierarchy">
+      <title>Specialization hierarchy</title>
+      <p>The <xmlelement>organizationname</xmlelement> element is specialized from
+          <xmlelement>ph</xmlelement>. It is defined in the XNAL domain module.</p>
+    </section>
+    <section id="attributes">
+      <title>Attributes</title>
+      <p conkeyref="reuse-attributes/universal-keyref"/>
+    </section>
+    <example id="example" otherprops="examples">
+      <title>Example</title>
+      <p>The following code sample shows how the <xmlelement>organizationname</xmlelement> element
+        can be used to provide detailed information about the authoring organization:</p>
+      <codeblock id="codeblock_xdt_rr2_nwb">&lt;bookmeta>
+ &lt;authorinformation&gt;
+  &lt;organizationinfo&gt;
+   &lt;namedetails&gt;
+    &lt;organizationnamedetails&gt;
+     <b>&lt;organizationname&gt;</b>WizardWorks, Inc.<b>&lt;/organizationname&gt;</b>
+     &lt;otherinfo&gt;'Best wizard in Oz'&lt;/otherinfo&gt;
+    &lt;/organizationnamedetails&gt;
+   &lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+    &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+    &lt;locality&gt;Emerald City&lt;/locality&gt;
+    &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+    &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+   &lt;urls&gt;&lt;url&gt;www.wizardworks.example.org&lt;/url&gt;&lt;/urls&gt;
+  &lt;/organizationinfo&gt;
+ &lt;/authorinformation&gt;
+&lt;/bookmeta></codeblock></example>
+  </refbody>
+</reference>

--- a/src/xnal/specification/technicalContent/organizationnamedetails.dita
+++ b/src/xnal/specification/technicalContent/organizationnamedetails.dita
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="organizationnamedetails" xml:lang="en-us">
+  <title><xmlelement>organizationnamedetails</xmlelement></title>
+  <shortdesc>The <xmlelement>organizationnamedetails</xmlelement> element specifies detailed
+    information about the name of an authoring organization.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>organizationnamedetails<indexterm>xNAL
+              elements<indexterm>organizationnamedetails</indexterm></indexterm></indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <refbody>
+    <section id="specialization-hierarchy">
+      <title>Specialization hierarchy</title>
+      <p>The <xmlelement>organizationnamedetails</xmlelement> element is specialized from
+          <xmlelement>ph</xmlelement>. It is defined in the XNAL domain module.</p>
+    </section>
+    <section id="attributes">
+      <title>Attributes</title>
+      <p conkeyref="reuse-attributes/universal-keyref"/>
+    </section>
+    <example id="example" otherprops="examples">
+      <title>Example</title>
+      <p>The following code sample shows how the <xmlelement>organizationnamedetails</xmlelement>
+        element can be used to provide detailed information about the name of an authoring
+        organization:</p>
+      <codeblock id="codeblock_xdt_rr2_nwb">&lt;bookmeta>
+ &lt;authorinformation&gt;
+ &lt;organizationinfo&gt;
+   &lt;namedetails&gt;
+    <b>&lt;organizationnamedetails&gt;</b>
+     &lt;organizationname&gt;WizardWorks, Inc.&lt;/organizationname&gt;
+     &lt;otherinfo&gt;'Best wizard in Oz'&lt;/otherinfo&gt;
+    <b>&lt;/organizationnamedetails&gt;</b>
+   &lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+    &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+    &lt;locality&gt;Emerald City&lt;/locality&gt;
+    &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+    &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+   &lt;urls&gt;&lt;url&gt;www.wizardworks.example.org&lt;/url&gt;&lt;/urls&gt;
+ &lt;/organizationinfo&gt;
+ &lt;/authorinformation&gt;
+&lt;/bookmeta></codeblock></example>
+  </refbody>
+</reference>

--- a/src/xnal/specification/technicalContent/otherinfo.dita
+++ b/src/xnal/specification/technicalContent/otherinfo.dita
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="otherinfo" xml:lang="en-us">
+  <title><xmlelement>otherinfo</xmlelement></title>
+  <shortdesc>The <xmlelement>otherinfo</xmlelement> element specifies additional detailed
+    information about the name of an author or authoring organization.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>otherinfo<indexterm>xNAL
+          elements<indexterm>otherinfo</indexterm></indexterm></indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <refbody>
+    <section id="specialization-hierarchy">
+      <title>Specialization hierarchy</title>
+      <p>The <xmlelement>otherinfo</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
+    </section>
+    <section id="attributes">
+      <title>Attributes</title>
+      <p conkeyref="reuse-attributes/data-link-universal-outputclass"/>
+    </section>
+    <example id="example" otherprops="examples">
+      <title>Example</title>
+      <p>The following code sample shows how the <xmlelement>otherinfo</xmlelement> element can be
+        used to provide detailed information about the name of an author
+          (<xmlelement>personinfo</xmlelement>) or the name of an authoring organization
+          (<xmlelement>organizationinfo</xmlelement>):</p>
+      <codeblock id="codeblock_xdt_rr2_nwb">&lt;bookmeta>
+ &lt;authorinformation&gt;
+  &lt;personinfo&gt;
+   &lt;namedetails&gt;&lt;personname&gt;
+     &lt;firstname&gt;Derek&lt;/firstname&gt;
+     &lt;middlename&gt;L.&lt;/middlename&gt;
+     &lt;lastname&gt;Singleton&lt;/lastname&gt;
+     &lt;generationidentifier&gt;Jr.&lt;/generationidentifier&gt;
+     <b>&lt;otherinfo&gt;</b>noted psychologist<b>&lt;/otherinfo&gt;</b>
+   &lt;/personname&gt;&lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+     &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+     &lt;locality&gt;Emerald City&lt;/locality&gt;
+     &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+     &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+  &lt;/personinfo&gt;
+  &lt;organizationinfo&gt;
+   &lt;namedetails&gt;
+    &lt;organizationnamedetails&gt;
+     &lt;organizationname&gt;WizardWorks, Inc.&lt;/organizationname&gt;
+     <b>&lt;otherinfo&gt;</b>'Best wizard in Oz'<b>&lt;/otherinfo&gt;</b>
+    &lt;/organizationnamedetails&gt;
+   &lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+    &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+    &lt;locality&gt;Emerald City&lt;/locality&gt;
+    &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+    &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+   &lt;urls&gt;&lt;url&gt;www.wizardworks.example.org&lt;/url&gt;&lt;/urls&gt;
+  &lt;/organizationinfo&gt;
+ &lt;/authorinformation&gt;
+&lt;/bookmeta></codeblock></example>
+  </refbody>
+</reference>

--- a/src/xnal/specification/technicalContent/personinfo.dita
+++ b/src/xnal/specification/technicalContent/personinfo.dita
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="personinfo" xml:lang="en-us">
+  <title><xmlelement>personinfo</xmlelement></title>
+  <shortdesc>The <xmlelement>personinfo</xmlelement> element specifies detailed information about an
+    author, including name, address, and contact information.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>personinfo<indexterm>xNAL
+          elements<indexterm>personinfo</indexterm></indexterm></indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <refbody>
+    <section id="specialization-hierarchy">
+      <title>Specialization hierarchy</title>
+      <p>The <xmlelement>personinfo</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
+    </section>
+    <section id="attributes">
+      <title>Attributes</title>
+      <p conkeyref="reuse-attributes/data-link-universal-outputclass"/>
+    </section>
+    <example id="example" otherprops="examples">
+      <title>Example</title>
+      <p>The following code sample shows how the <xmlelement>personinfo</xmlelement> element can be
+        used to provide detailed information about an author:</p>
+      <codeblock id="codeblock_xdt_rr2_nwb">&lt;bookmeta>
+ &lt;authorinformation&gt;
+  <b>&lt;personinfo&gt;</b>
+   &lt;namedetails&gt;&lt;personname&gt;
+     &lt;firstname&gt;Derek&lt;/firstname&gt;
+     &lt;middlename&gt;L.&lt;/middlename&gt;
+     &lt;lastname&gt;Singleton&lt;/lastname&gt;
+     &lt;generationidentifier&gt;Jr.&lt;/generationidentifier&gt;
+     &lt;otherinfo&gt;noted psychologist&lt;/otherinfo&gt;
+    &lt;/personname&gt;&lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+     &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+     &lt;locality&gt;Emerald City&lt;/locality&gt;
+     &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+     &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+ <b>&lt;/personinfo&gt;</b>
+ &lt;/authorinformation&gt;
+&lt;/bookmeta></codeblock></example>
+  </refbody>
+</reference>

--- a/src/xnal/specification/technicalContent/personname.dita
+++ b/src/xnal/specification/technicalContent/personname.dita
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="personname" xml:lang="en-us">
+  <title><xmlelement>personname</xmlelement></title>
+  <shortdesc>The <xmlelement>personname</xmlelement> element specifies detailed information about
+    the name of an author.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>personname<indexterm>xNAL
+          elements<indexterm>personname</indexterm></indexterm></indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <refbody>
+    <section id="specialization-hierarchy">
+      <title>Specialization hierarchy</title>
+      <p>The <xmlelement>personname</xmlelement> element is specialized from
+          <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
+    </section>
+    <section id="attributes">
+      <title>Attributes</title>
+      <p conkeyref="reuse-attributes/data-link-universal-outputclass"/>
+    </section>
+    <example id="example" otherprops="examples">
+      <title>Example</title>
+      <p>The following code sample shows how the <xmlelement>personname</xmlelement> element can be
+        used to provide detailed information about the name of an author:</p>
+      <codeblock id="codeblock_xdt_rr2_nwb">&lt;bookmeta>
+ &lt;authorinformation&gt;
+  &lt;personinfo&gt;
+   &lt;namedetails&gt;
+    <b>&lt;personname&gt;</b>
+     &lt;firstname&gt;Derek&lt;/firstname&gt;
+     &lt;middlename&gt;L.&lt;/middlename&gt;
+     &lt;lastname&gt;Singleton&lt;/lastname&gt;
+     &lt;generationidentifier&gt;Jr.&lt;/generationidentifier&gt;
+     &lt;otherinfo&gt;noted psychologist&lt;/otherinfo&gt;
+    <b>&lt;/personname&gt;</b>
+   &lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+    &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+    &lt;locality&gt;Emerald City&lt;/locality&gt;
+     &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+     &lt;country&gt;USA&lt;/country&gt;
+    &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+  &lt;/personinfo&gt;
+ &lt;/authorinformation&gt;
+&lt;/bookmeta></codeblock></example>
+  </refbody>
+</reference>

--- a/src/xnal/specification/technicalContent/postalcode.dita
+++ b/src/xnal/specification/technicalContent/postalcode.dita
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="postalcode" xml:lang="en-us">
+  <title><xmlelement>postalcode</xmlelement></title>
+  <shortdesc>The <xmlelement>postalcode</xmlelement> element specifies information about a postal
+    code or ZIP code for an author or authoring organization.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>xNAL elements<indexterm>postalcode</indexterm></indexterm>
+        <indexterm>postalcode</indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <refbody>
+    <section id="specialization-hierarchy">
+      <title>Specialization hierarchy</title>
+      <p>The <xmlelement>postalcode</xmlelement> element is specialized from
+          <xmlelement>ph</xmlelement>. It is defined in the XNAL domain module.</p>
+    </section>
+    <section id="attributes">
+      <title>Attributes</title>
+      <p conkeyref="reuse-attributes/universal-keyref"/>
+    </section>
+    <example id="example" otherprops="examples">
+      <title>Example</title>
+      <p>The following code sample shows how the <xmlelement>postalcode</xmlelement> element can be
+        used to provide information about a postal code or ZIP code for an author or authoring
+        organization:</p>
+      <codeblock id="codeblock_xdt_rr2_nwb">&lt;bookmeta>
+ &lt;authorinformation&gt;
+  &lt;personinfo&gt;
+   &lt;namedetails&gt;&lt;personname&gt;
+     &lt;firstname&gt;Derek&lt;/firstname&gt;
+     &lt;middlename&gt;L.&lt;/middlename&gt;
+     &lt;lastname&gt;Singleton&lt;/lastname&gt;
+     &lt;generationidentifier&gt;Jr.&lt;/generationidentifier&gt;
+     &lt;otherinfo&gt;noted psychologist&lt;/otherinfo&gt;
+   &lt;/personname&gt;&lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+     &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+     &lt;locality&gt;
+      &lt;localityname&gt;Emerald City&lt;/localityname&gt;
+      <b>&lt;postalcode&gt;</b>66780<b>&lt;/postalcode&gt;</b>
+     &lt;/locality&gt;
+     &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+     &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+  &lt;/personinfo&gt;
+  &lt;organizationinfo&gt;
+   &lt;namedetails&gt;
+    &lt;organizationnamedetails&gt;
+     &lt;organizationname&gt;WizardWorks, Inc.&lt;/organizationname&gt;
+     &lt;otherinfo&gt;'Best wizard in Oz'&lt;/otherinfo&gt;
+    &lt;/organizationnamedetails&gt;
+   &lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+    &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+     &lt;locality&gt;
+      &lt;localityname&gt;Emerald City&lt;/localityname&gt;
+      <b>&lt;postalcode&gt;</b>66780<b>&lt;/postalcode&gt;</b>
+     &lt;/locality&gt;
+    &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+    &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+   &lt;urls&gt;&lt;url&gt;www.wizardworks.example.org&lt;/url&gt;&lt;/urls&gt;
+  &lt;/organizationinfo&gt;
+ &lt;/authorinformation&gt;
+&lt;/bookmeta></codeblock></example>
+  </refbody>
+</reference>

--- a/src/xnal/specification/technicalContent/thoroughfare.dita
+++ b/src/xnal/specification/technicalContent/thoroughfare.dita
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="thoroughfare" xml:lang="en-us">
+  <title><xmlelement>thoroughfare</xmlelement></title>
+  <shortdesc>The <xmlelement>thoroughfare</xmlelement> element specifies for an author or authoring
+    organization information about the thoroughfare, for example the street, avenue, or boulevard on
+    which an address is located.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>xNAL elements<indexterm>thoroughfare</indexterm></indexterm>
+        <indexterm>thoroughfare</indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <refbody>
+    <section id="specialization-hierarchy">
+      <title>Specialization hierarchy</title>
+      <p>The <xmlelement>thoroughfare</xmlelement> element is specialized from
+          <xmlelement>ph</xmlelement>. It is defined in the XNAL domain module.</p>
+    </section>
+    <section id="attributes">
+      <title>Attributes</title>
+      <p conkeyref="reuse-attributes/universal-keyref"/>
+    </section>
+    <example id="example" otherprops="examples">
+      <title>Example</title>
+      <p>The following code sample shows how the <xmlelement>thoroughfare</xmlelement> element can
+        be used to provide detailed information about a thoroughfare, for example the street,
+        avenue, or boulevard on which an address is located:</p>
+      <codeblock id="codeblock_xdt_rr2_nwb">&lt;bookmeta>
+ &lt;authorinformation&gt;
+  &lt;personinfo&gt;
+   &lt;namedetails&gt;&lt;personname&gt;
+     &lt;firstname&gt;Derek&lt;/firstname&gt;
+     &lt;middlename&gt;L.&lt;/middlename&gt;
+     &lt;lastname&gt;Singleton&lt;/lastname&gt;
+     &lt;generationidentifier&gt;Jr.&lt;/generationidentifier&gt;
+     &lt;otherinfo&gt;noted psychologist&lt;/otherinfo&gt;
+   &lt;/personname&gt;&lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+    <b>&lt;thoroughfare&gt;</b>123 Yellow Brick Road<b>&lt;/thoroughfare&gt;</b>
+    &lt;locality&gt;
+     &lt;localityname&gt;Emerald City&lt;/localityname&gt;
+     &lt;postalcode&gt;66780&lt;/postalcode&gt;
+    &lt;/locality&gt;
+    &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+    &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+  &lt;/personinfo&gt;
+  &lt;organizationinfo&gt;
+   &lt;namedetails&gt;
+    &lt;organizationnamedetails&gt;
+     &lt;organizationname&gt;WizardWorks, Inc.&lt;/organizationname&gt;
+     &lt;otherinfo&gt;noted psychologist&lt;/otherinfo&gt;
+     &lt;/organizationnamedetails&gt;
+   &lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+    <b>&lt;thoroughfare&gt;</b>123 Yellow Brick Road<b>&lt;/thoroughfare&gt;</b>
+    &lt;locality&gt;
+     &lt;localityname&gt;Emerald City&lt;/localityname&gt;
+     &lt;postalcode&gt;66780&lt;/postalcode&gt;
+    &lt;/locality&gt;
+    &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+    &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+   &lt;urls&gt;&lt;url&gt;www.wizardworks.example.org&lt;/url&gt;&lt;/urls&gt;
+  &lt;/organizationinfo&gt;
+ &lt;/authorinformation&gt;
+&lt;/bookmeta></codeblock></example>
+  </refbody>
+</reference>

--- a/src/xnal/specification/technicalContent/url.dita
+++ b/src/xnal/specification/technicalContent/url.dita
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="url" xml:lang="en-us">
+  <title><xmlelement>url</xmlelement></title>
+  <shortdesc>The <xmlelement>url</xmlelement> element specifies a Uniform Resource Locator (URL) for
+    an authoring organization. </shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>xNAL elements<indexterm>url</indexterm></indexterm>
+        <indexterm>url</indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <refbody>
+    <section id="specialization-hierarchy">
+      <title>Specialization hierarchy</title>
+      <p>The <xmlelement>url</xmlelement> element is specialized from <xmlelement>data</xmlelement>.
+        It is defined in the XNAL domain module.</p>
+    </section>
+    <section id="attributes">
+      <title>Attributes</title>
+      <p conkeyref="reuse-attributes/data-link-universal-outputclass"/>
+    </section>
+    <example id="example" otherprops="examples">
+      <title>Example</title>
+      <p>The following code sample shows how the <xmlelement>url</xmlelement> element can be used to
+        specify a Uniform Resource Locator (URL) for an authoring organization:</p>
+      <codeblock id="codeblock_xdt_rr2_nwb">&lt;bookmeta>
+ &lt;authorinformation&gt;
+  &lt;personinfo&gt;
+   &lt;namedetails&gt;&lt;personname&gt;
+     &lt;firstname&gt;Derek&lt;/firstname&gt;
+     &lt;middlename&gt;L.&lt;/middlename&gt;
+     &lt;lastname&gt;Singleton&lt;/lastname&gt;
+     &lt;generationidentifier&gt;Jr.&lt;/generationidentifier&gt;
+     &lt;otherinfo&gt;noted psychologist&lt;/otherinfo&gt;
+   &lt;/personname&gt;&lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+     &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+     &lt;locality&gt;
+      &lt;localityname&gt;Emerald City&lt;/localityname&gt;
+      &lt;postalcode&gt;66780&lt;/postalcode&gt;
+     &lt;/locality&gt;
+     &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+     &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+  &lt;/personinfo&gt;
+  &lt;organizationinfo&gt;
+   &lt;namedetails&gt;
+    &lt;organizationnamedetails&gt;
+     &lt;organizationname&gt;WizardWorks, Inc.&lt;/organizationname&gt;
+     &lt;otherinfo&gt;noted psychologist&lt;/otherinfo&gt;
+     &lt;/organizationnamedetails&gt;
+   &lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+    &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+     &lt;locality&gt;
+      &lt;localityname&gt;Emerald City&lt;/localityname&gt;
+      &lt;postalcode&gt;66780&lt;/postalcode&gt;
+      &lt;/locality&gt;
+    &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+    &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt; 
+   &lt;urls&gt;<b>&lt;url&gt;</b>www.wizardworks.example.org<b>&lt;/url&gt;</b>&lt;/urls&gt;
+  &lt;/organizationinfo&gt;
+ &lt;/authorinformation&gt;
+&lt;/bookmeta></codeblock></example>
+  </refbody>
+</reference>

--- a/src/xnal/specification/technicalContent/urls.dita
+++ b/src/xnal/specification/technicalContent/urls.dita
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN"
+ "reference.dtd">
+<reference id="urls" xml:lang="en-us">
+  <title><xmlelement>urls</xmlelement></title>
+  <shortdesc>The <xmlelement>urls</xmlelement> element specifies one or more Uniform Resource
+    Locators (URLs) for an authoring organization.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>urls<indexterm>xNAL elements<indexterm>urls</indexterm></indexterm></indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <refbody>
+    <section id="specialization-hierarchy">
+      <title>Specialization hierarchy</title>
+      <p>The <xmlelement>urls</xmlelement> element is specialized from
+        <xmlelement>data</xmlelement>. It is defined in the XNAL domain module.</p>
+    </section>
+    <section id="attributes">
+      <title>Attributes</title>
+      <p conkeyref="reuse-attributes/data-link-universal-outputclass"/>
+    </section>
+    <example id="example" otherprops="examples">
+      <title>Example</title>
+      <p>The following code sample shows how the <xmlelement>urls</xmlelement> element can be used
+        to list one or more Uniform Resource Locators (URLs) for an authoring organization:</p>
+      <codeblock id="codeblock_xdt_rr2_nwb">&lt;bookmeta>
+ &lt;authorinformation&gt;
+  &lt;personinfo&gt;
+   &lt;namedetails&gt;&lt;personname&gt;
+     &lt;firstname&gt;Derek&lt;/firstname&gt;
+     &lt;middlename&gt;L.&lt;/middlename&gt;
+     &lt;lastname&gt;Singleton&lt;/lastname&gt;
+     &lt;generationidentifier&gt;Jr.&lt;/generationidentifier&gt;
+     &lt;otherinfo&gt;noted psychologist&lt;/otherinfo&gt;
+   &lt;/personname&gt;&lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+     &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+     &lt;locality&gt;
+      &lt;localityname&gt;Emerald City&lt;/localityname&gt;
+      &lt;postalcode&gt;66780&lt;/postalcode&gt;
+     &lt;/locality&gt;
+     &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+     &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt;
+  &lt;/personinfo&gt;
+  &lt;organizationinfo&gt;
+   &lt;namedetails&gt;
+    &lt;organizationnamedetails&gt;
+     &lt;organizationname&gt;WizardWorks, Inc.&lt;/organizationname&gt;
+     &lt;otherinfo&gt;noted psychologist&lt;/otherinfo&gt;
+     &lt;/organizationnamedetails&gt;
+   &lt;/namedetails&gt;
+   &lt;addressdetails&gt;
+    &lt;thoroughfare&gt;123 Yellow Brick Road&lt;/thoroughfare&gt;
+     &lt;locality&gt;
+      &lt;localityname&gt;Emerald City&lt;/localityname&gt;
+      &lt;postalcode&gt;66780&lt;/postalcode&gt;
+      &lt;/locality&gt;
+    &lt;administrativearea&gt;Kansas&lt;/administrativearea&gt;
+    &lt;country&gt;USA&lt;/country&gt;
+   &lt;/addressdetails&gt;
+   &lt;contactnumbers&gt;&lt;contactnumber&gt;123-555-4678&lt;/contactnumber&gt;&lt;/contactnumbers&gt;
+   &lt;emailaddresses&gt;&lt;emailaddress&gt;wizard@example.org&lt;/emailaddress&gt;&lt;/emailaddresses&gt; 
+   <b>&lt;urls&gt;</b>&lt;url&gt;www.wizardworks.example.org&lt;/url&gt;<b>&lt;/urls&gt;</b>
+  &lt;/organizationinfo&gt;
+ &lt;/authorinformation&gt;
+&lt;/bookmeta></codeblock></example>
+  </refbody>
+</reference>

--- a/src/xnal/specification/xnal-domain-elements.ditamap
+++ b/src/xnal/specification/xnal-domain-elements.ditamap
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+    <title>XNAL domain elements</title>
+    <topicref href="containers/xnal-d.dita">
+        <topicref href="technicalContent/authorinformation.dita"/>
+        <topicref href="technicalContent/addressdetails.dita"/>
+        <topicref href="technicalContent/administrativearea.dita"/>
+        <topicref href="technicalContent/contactnumber.dita"/>
+        <topicref href="technicalContent/contactnumbers.dita"/>
+        <topicref href="technicalContent/country.dita"/>
+        <topicref href="technicalContent/emailaddress.dita"/>
+        <topicref href="technicalContent/emailaddresses.dita"/>
+        <topicref href="technicalContent/firstname.dita"/>
+        <topicref href="technicalContent/generationidentifier.dita"/>
+        <topicref href="technicalContent/honorific.dita"/>
+        <topicref href="technicalContent/lastname.dita"/>
+        <topicref href="technicalContent/locality.dita"/>
+        <topicref href="technicalContent/localityname.dita"/>
+        <topicref href="technicalContent/middlename.dita"/>
+        <topicref href="technicalContent/namedetails.dita"/>
+        <topicref href="technicalContent/organizationinfo.dita"/>
+        <topicref href="technicalContent/organizationname.dita"/>
+        <topicref href="technicalContent/organizationnamedetails.dita"/>
+        <topicref href="technicalContent/otherinfo.dita"/>
+        <topicref href="technicalContent/personinfo.dita"/>
+        <topicref href="technicalContent/personname.dita"/>
+        <topicref href="technicalContent/postalcode.dita"/>
+        <topicref href="technicalContent/thoroughfare.dita"/>
+        <topicref href="technicalContent/url.dita"/>
+        <topicref href="technicalContent/urls.dita"/>
+    </topicref>
+</map>


### PR DESCRIPTION
xNAL is being removed from the core DITA 2.0 technical communications spec, but remains available in this repo for use as a plugin.

Based on TC decision March 28 2023; see https://github.com/oasis-tcs/dita/issues/898